### PR TITLE
Release 1.1/Basic Shader Pipeline

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -25,7 +25,8 @@ project "Engine"
 	}
     files
 	{
-		"source/engine/**.h", "source/engine/**.cpp"
+		"source/engine/**.h", "source/engine/**.cpp",
+		"source/engine/shaders/**.hlsl"
 	}
 	symbolspath '$(OutDir)$(TargetName).pdb'
 	filter "configurations:Final"
@@ -33,6 +34,8 @@ project "Engine"
 		postbuildcommands { "{COPYFILE} %[%{!wks.location}../source/engine/shaders/shaders.hlsl] %[%{!cfg.targetdir}]" }
 	filter "configurations:Debug"
 		defines { "DEBUG" }
+	filter("files:**.hlsl")
+		flags("ExcludeFromBuild")
 	
 project "Game"
     kind "ConsoleApp"

--- a/premake5.lua
+++ b/premake5.lua
@@ -31,7 +31,8 @@ project "Engine"
 	symbolspath '$(OutDir)$(TargetName).pdb'
 	filter "configurations:Final"
 		defines { "FINAL" }
-		postbuildcommands { "{COPYFILE} %[%{!wks.location}../source/engine/shaders/shaders.hlsl] %[%{!cfg.targetdir}]" }
+		buildcommands  { "{COPYFILE} %[%{!wks.location}../source/engine/shaders/**.hlsl] %[%{!cfg.targetdir}]" } -- Runs before the compilation
+		buildoutputs { "%{cfg.targetdir}/.timestamp" } -- Technically creates a dummy file to track execution, but I've never found this file
 	filter "configurations:Debug"
 		defines { "DEBUG" }
 	filter("files:**.hlsl")

--- a/source/engine/RenderContext.cpp
+++ b/source/engine/RenderContext.cpp
@@ -129,7 +129,7 @@ UINT RenderContext::CreateRootSignature(DeviceContext* deviceContext)
 	return index;
 }
 
-UINT RenderContext::CreateShaders(DeviceContext* deviceContext)
+UINT RenderContext::CreateShaders(LPCWSTR shaderName)
 {
 	OutputDebugString(L"CreateShaders\n");
 
@@ -143,13 +143,24 @@ UINT RenderContext::CreateShaders(DeviceContext* deviceContext)
 	ID3DBlob* vertexShader;
 	ID3DBlob* pixelShader;
 #if defined(DEBUG)
+	// Concatenate the directory and the file name
+	LPCWSTR shaderDir = L"../source/engine/shaders/";
+	size_t shaderNameLength = wcslen(shaderName);
+	size_t shaderDirLength = wcslen(shaderDir);
+	size_t fullPathLength = shaderNameLength + shaderDirLength + 1;
+	wchar_t* fullPath = new wchar_t[fullPathLength];
+	wcscpy_s(fullPath, fullPathLength, shaderDir);
+	wcscat_s(fullPath, fullPathLength, shaderName);
+
 	// If you run from VS, the working directory is build, so we need to go up one level
-	ExitIfFailed(D3DCompileFromFile(L"../source/engine/shaders/shaders.hlsl", nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-	ExitIfFailed(D3DCompileFromFile(L"../source/engine/shaders/shaders.hlsl", nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+	ExitIfFailed(D3DCompileFromFile(fullPath, nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
+	ExitIfFailed(D3DCompileFromFile(fullPath, nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+
+	delete[] fullPath;
 #else
 	// In final we will copy shaders to the bin directory
-	ExitIfFailed(D3DCompileFromFile(L"shaders.hlsl", nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-	ExitIfFailed(D3DCompileFromFile(L"shaders.hlsl", nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+	ExitIfFailed(D3DCompileFromFile(shaderName, nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
+	ExitIfFailed(D3DCompileFromFile(shaderName, nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
 #endif
 	UINT index = vertexShaders.size();
 	vertexShaders.push_back(vertexShader);

--- a/source/engine/RenderContext.h
+++ b/source/engine/RenderContext.h
@@ -21,7 +21,7 @@ public:
 	void CreateDescriptorHeap(DeviceContext* deviceContext);
 	void CreateRenderTargetFromBackBuffer(DeviceContext* deviceContext);
 	UINT CreateRootSignature(DeviceContext* deviceContext);
-	UINT CreateShaders(DeviceContext* deviceContext);
+	UINT CreateShaders(LPCWSTR shaderName);
 	UINT CreatePipelineState(DeviceContext* deviceContext, UINT rootSignatureIndex, UINT shaderIndex);
 	UINT CreateViewportAndScissorRect(DeviceContext* deviceContext);
 	void CreateVertexBuffer(DeviceContext* deviceContext);

--- a/source/engine/RenderPass.cpp
+++ b/source/engine/RenderPass.cpp
@@ -1,10 +1,12 @@
 #include "RenderPass.h"
 #include "RenderContext.h"
 
+#include <assert.h>
+
 extern RenderContext renderContext;
 extern DeviceContext deviceContext;
 
-RenderPass::RenderPass()
+RenderPass::RenderPass() : shaderSourceFileName(L"shaders.hlsl")
 {
 }
 
@@ -15,7 +17,7 @@ RenderPass::~RenderPass()
 void RenderPass::AutomaticPrepare()
 {
 	rootSignatureIndex = renderContext.CreateRootSignature(&deviceContext);
-	shaderIndex = renderContext.CreateShaders(&deviceContext);
+	shaderIndex = renderContext.CreateShaders(shaderSourceFileName);
 	pipelineStateIndex = renderContext.CreatePipelineState(&deviceContext, rootSignatureIndex, shaderIndex);
 	viewportAndScissorsIndex = renderContext.CreateViewportAndScissorRect(&deviceContext);
 	commandListIndex = renderContext.CreateCommandList();

--- a/source/engine/RenderPass.h
+++ b/source/engine/RenderPass.h
@@ -24,4 +24,5 @@ protected:
 	UINT commandListIndex;
 	UINT renderTargetIndex;
 	UINT depthBufferIndex;
+	LPCWSTR shaderSourceFileName;
 };


### PR DESCRIPTION
Added couple quality of life improvements, like making HSLS files a part of the solution and automatically copying shader source files to the Final configuration folder. Extracted shader creation, so that each Render Pass can have its own set of shaders. Note that for now, each Render Pass will have the same, default shader - this will be fixed in the future.