### PR TITLE
Drawless Render Pass

### DIFF
--- a/source/engine/BlitPass.cpp
+++ b/source/engine/BlitPass.cpp
@@ -7,7 +7,7 @@
 extern DeviceContext deviceContext;
 extern RenderContext renderContext;
 
-BlitPass::BlitPass() : RenderPass(L"Blit")
+BlitPass::BlitPass() : RenderPass(L"Blit", Type::Drawless)
 {
 }
 

--- a/source/engine/RenderContext.cpp
+++ b/source/engine/RenderContext.cpp
@@ -153,8 +153,8 @@ UINT RenderContext::CreateShaders(LPCWSTR shaderName)
 	wcscat_s(fullPath, fullPathLength, shaderName);
 
 	// If you run from VS, the working directory is build, so we need to go up one level
-	ExitIfFailed(D3DCompileFromFile(shaderName, nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
-	ExitIfFailed(D3DCompileFromFile(shaderName, nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
+	ExitIfFailed(D3DCompileFromFile(fullPath, nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr));
+	ExitIfFailed(D3DCompileFromFile(fullPath, nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr));
 
 	delete[] fullPath;
 #else
@@ -445,9 +445,14 @@ void RenderContext::ClearDepthBuffer(UINT cmdListIndex, UINT depthIndex)
 	commandLists[cmdListIndex]->GetCommandList()->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
 }
 
+void RenderContext::ResetCommandList(UINT cmdListindex, UINT psoIndex)
+{
+	commandLists[cmdListindex]->Reset(pipelineStates[psoIndex]);
+}
+
 void RenderContext::ResetCommandList(UINT index)
 {
-	commandLists[index]->Reset(pipelineStates[index]);
+	commandLists[index]->Reset(nullptr);
 }
 
 void RenderContext::CloseCommandList(UINT index)

--- a/source/engine/RenderContext.h
+++ b/source/engine/RenderContext.h
@@ -48,6 +48,7 @@ public:
 	// Binding
 	void BindRenderTarget(UINT cmdListIndex, UINT rtIndex);
 	void BindRenderTargetWithDepth(UINT cmdListIndex, UINT rtIndex, UINT depthIndex);
+	void ResetCommandList(UINT index, UINT psoIndex);
 	void ResetCommandList(UINT index);
 	void CloseCommandList(UINT index);
 	void SetupRenderPass(UINT cmdListIndex, UINT psoIndex, UINT rootSignatureIndex, UINT viewportIndex, UINT scissorsIndex);

--- a/source/engine/RenderPass.cpp
+++ b/source/engine/RenderPass.cpp
@@ -11,7 +11,7 @@
 extern RenderContext renderContext;
 extern DeviceContext deviceContext;
 
-RenderPass::RenderPass(PCWSTR name) : shaderSourceFileName(L"shaders.hlsl"), name(name)
+RenderPass::RenderPass(PCWSTR name, Type type) : shaderSourceFileName(L"shaders.hlsl"), name(name), type(type)
 {
 }
 
@@ -21,10 +21,13 @@ RenderPass::~RenderPass()
 
 void RenderPass::AutomaticPrepare()
 {
-	rootSignatureIndex = renderContext.CreateRootSignature(&deviceContext);
-	shaderIndex = renderContext.CreateShaders(shaderSourceFileName);
-	pipelineStateIndex = renderContext.CreatePipelineState(&deviceContext, rootSignatureIndex, shaderIndex);
-	viewportAndScissorsIndex = renderContext.CreateViewportAndScissorRect(&deviceContext);
+	if (GetType() == Type::Default)
+	{
+		rootSignatureIndex = renderContext.CreateRootSignature(&deviceContext);
+		shaderIndex = renderContext.CreateShaders(shaderSourceFileName);
+		pipelineStateIndex = renderContext.CreatePipelineState(&deviceContext, rootSignatureIndex, shaderIndex);
+		viewportAndScissorsIndex = renderContext.CreateViewportAndScissorRect(&deviceContext);
+	}
 
 	commandListIndex = renderContext.CreateCommandList();
 }
@@ -45,7 +48,14 @@ void RenderPass::Update()
 
 void RenderPass::PreExecute()
 {
-	renderContext.ResetCommandList(commandListIndex);
+	if (GetType() == Type::Default)
+	{
+		renderContext.ResetCommandList(commandListIndex, pipelineStateIndex);
+	}
+	else if (GetType() == Type::Drawless)
+	{
+		renderContext.ResetCommandList(commandListIndex);
+	}
 	PIXBeginEvent(renderContext.GetCommandList(commandListIndex)->GetCommandList(), 0, name);
 }
 

--- a/source/engine/RenderPass.h
+++ b/source/engine/RenderPass.h
@@ -9,7 +9,12 @@ class RenderContext;
 class RenderPass
 {
 public:
-	RenderPass(PCWSTR name);
+	enum Type
+	{
+		Default,
+		Drawless
+	};
+	RenderPass(PCWSTR name, RenderPass::Type type);
 	~RenderPass();
 	void AutomaticPrepare();
 	virtual void Prepare();
@@ -18,7 +23,9 @@ public:
 	virtual void Execute() = 0;
 	void PostExecute();
 	virtual void Allocate(DeviceContext* deviceContext) = 0;
+	RenderPass::Type GetType() const { return type; }
 protected:
+	RenderPass::Type type;
 	UINT shaderIndex;
 	UINT rootSignatureIndex;
 	UINT pipelineStateIndex;

--- a/source/engine/TestPass.cpp
+++ b/source/engine/TestPass.cpp
@@ -8,7 +8,7 @@
 extern DeviceContext deviceContext;
 extern RenderContext renderContext;
 
-TestPass::TestPass() : RenderPass(L"Test")
+TestPass::TestPass() : RenderPass(L"Test", Type::Default)
 {
 	camera = new PerspectiveCamera(1.0f, DirectX::SimpleMath::Vector3(0.0f, 0.0f, 2.0f));
 	camera->SetPosition(DirectX::SimpleMath::Vector3(0.0f, 0.0f, 1.0f));


### PR DESCRIPTION
Added a new property to Render Pass - its type, which can be Default or Drawless (doesn't draw anything). Added overloaded ResetCommandList function, so that you don't provide PSO for Command List reset for Drawless passes. Finally, for Drawless passes, we are not creating any unnecessary resources, like shaders or PSOs.