### PR TITLE
Flexible Vertex Buffers

### DIFF
--- a/source/engine/BlitPass.cpp
+++ b/source/engine/BlitPass.cpp
@@ -15,15 +15,16 @@ BlitPass::~BlitPass()
 {
 }
 
+void BlitPass::ConfigurePipelineState()
+{
+}
+
 void BlitPass::Prepare()
 {
 }
 
 void BlitPass::Execute()
 {
-	//renderContext.ResetCommandList(commandListIndex);
-
-	//PIXBeginEvent(renderContext.GetCommandList(commandListIndex)->GetCommandList(), 0, L"Blit Pass");
 	renderContext.TransitionTo(commandListIndex, 2, D3D12_RESOURCE_STATE_COPY_SOURCE);
 	
 	auto frameIndex = deviceContext.GetCurrentBackBufferIndex();
@@ -32,10 +33,6 @@ void BlitPass::Execute()
 
 	renderContext.TransitionBack(commandListIndex, 2);
 	renderContext.TransitionTo(commandListIndex, frameIndex, D3D12_RESOURCE_STATE_PRESENT);
-	//PIXEndEvent(renderContext.GetCommandList(commandListIndex)->GetCommandList());
-	//
-	//renderContext.CloseCommandList(commandListIndex);
-	//renderContext.ExecuteCommandList(commandListIndex);
 }
 
 void BlitPass::Allocate(DeviceContext* deviceContext)

--- a/source/engine/BlitPass.h
+++ b/source/engine/BlitPass.h
@@ -9,6 +9,7 @@ class BlitPass : public RenderPass
 public:
 	BlitPass();
 	~BlitPass();
+	void ConfigurePipelineState() override;
 	void Prepare() override;
 	void Execute() override;
 	void Allocate(DeviceContext* deviceContext) override;

--- a/source/engine/Engine.cpp
+++ b/source/engine/Engine.cpp
@@ -80,9 +80,11 @@ void Engine::LoadAssets()
 			continue;
 		}
 		auto numOfTriangles = meshDescriptor.numOfVertices;
-		auto vbIndexPositionAndColor = renderContext.CreateVertexBuffer(numOfTriangles * 3, 4, meshOutput.data());
-		auto vbIndexColor = renderContext.GenerateColors(meshOutput.data(), meshOutput.size(), numOfTriangles);
-		renderContext.CreateMesh(vbIndexPositionAndColor, vbIndexColor);
+		CHAR tempName[64];
+		snprintf(tempName, sizeof(tempName), "POSITION_%s", meshName.c_str());
+		auto vbIndexPositionAndColor = renderContext.CreateVertexBuffer(numOfTriangles * 3, 4, meshOutput.data(), tempName);
+		auto vbIndexColor = renderContext.GenerateColors(meshOutput.data(), meshOutput.size(), numOfTriangles, meshName.c_str());
+		renderContext.CreateMesh(vbIndexPositionAndColor, vbIndexColor,meshName.c_str());
 	}
 }
 

--- a/source/engine/Engine.cpp
+++ b/source/engine/Engine.cpp
@@ -57,37 +57,33 @@ void Engine::LoadAssets()
 	//auto errorCode = assetManager.MeshGet("Suzanne_Mesh", AssetSuite::MeshOutputFormat::POSITION, meshOutput, meshDescriptor);
 	//auto errorCode = assetManager.MeshGet("teapot_Mesh", AssetSuite::MeshOutputFormat::POSITION, meshOutput, meshDescriptor);
 	//auto errorCode = assetManager.MeshGet("Cube_Mesh", AssetSuite::MeshOutputFormat::POSITION, meshOutput, meshDescriptor);
-	auto errorCode = assetManager.MeshGet("Building_Mesh", AssetSuite::MeshOutputFormat::POSITION, meshOutput, meshDescriptor);
-	auto numOfTriangles = meshDescriptor.numOfVertices;
-	renderContext.CreateMesh(meshOutput.data(), meshOutput.size(), numOfTriangles);
 
-	errorCode = assetManager.MeshGet("RoofBase_Mesh", AssetSuite::MeshOutputFormat::POSITION, meshOutput, meshDescriptor);
-	numOfTriangles = meshDescriptor.numOfVertices;
-	renderContext.CreateMesh(meshOutput.data(), meshOutput.size(), numOfTriangles);
+	std::vector<std::string> meshNames = {
+		"Building_Mesh",
+		"RoofBase_Mesh",
+		"ColumnOne_Mesh",
+		"ColumnTwo_Mesh",
+		"ColumnThree_Mesh",
+		"ColumnFour_Mesh",
+		"Roof_Mesh",
+		"RoofEdge_Mesh"
+	};
 
-	errorCode = assetManager.MeshGet("ColumnOne_Mesh", AssetSuite::MeshOutputFormat::POSITION, meshOutput, meshDescriptor);
-	numOfTriangles = meshDescriptor.numOfVertices;
-	renderContext.CreateMesh(meshOutput.data(), meshOutput.size(), numOfTriangles);
-
-	errorCode = assetManager.MeshGet("ColumnTwo_Mesh", AssetSuite::MeshOutputFormat::POSITION, meshOutput, meshDescriptor);
-	numOfTriangles = meshDescriptor.numOfVertices;
-	renderContext.CreateMesh(meshOutput.data(), meshOutput.size(), numOfTriangles);
-
-	errorCode = assetManager.MeshGet("ColumnThree_Mesh", AssetSuite::MeshOutputFormat::POSITION, meshOutput, meshDescriptor);
-	numOfTriangles = meshDescriptor.numOfVertices;
-	renderContext.CreateMesh(meshOutput.data(), meshOutput.size(), numOfTriangles);
-
-	errorCode = assetManager.MeshGet("ColumnFour_Mesh", AssetSuite::MeshOutputFormat::POSITION, meshOutput, meshDescriptor);
-	numOfTriangles = meshDescriptor.numOfVertices;
-	renderContext.CreateMesh(meshOutput.data(), meshOutput.size(), numOfTriangles);
-
-	errorCode = assetManager.MeshGet("Roof_Mesh", AssetSuite::MeshOutputFormat::POSITION, meshOutput, meshDescriptor);
-	numOfTriangles = meshDescriptor.numOfVertices;
-	renderContext.CreateMesh(meshOutput.data(), meshOutput.size(), numOfTriangles);
-
-	errorCode = assetManager.MeshGet("RoofEdge_Mesh", AssetSuite::MeshOutputFormat::POSITION, meshOutput, meshDescriptor);
-	numOfTriangles = meshDescriptor.numOfVertices;
-	renderContext.CreateMesh(meshOutput.data(), meshOutput.size(), numOfTriangles);
+	for (const auto& meshName : meshNames)
+	{
+		auto errorCode = assetManager.MeshGet(meshName.c_str(), AssetSuite::MeshOutputFormat::POSITION, meshOutput, meshDescriptor);
+		if (errorCode != AssetSuite::ErrorCode::OK)
+		{
+			OutputDebugString(L"Failed to load mesh: ");
+			OutputDebugStringA(meshName.c_str());
+			OutputDebugString(L"\n");
+			continue;
+		}
+		auto numOfTriangles = meshDescriptor.numOfVertices;
+		auto vbIndexPositionAndColor = renderContext.CreateVertexBuffer(numOfTriangles * 3, 4, meshOutput.data());
+		auto vbIndexColor = renderContext.GenerateColors(meshOutput.data(), meshOutput.size(), numOfTriangles);
+		renderContext.CreateMesh(vbIndexPositionAndColor, vbIndexColor);
+	}
 }
 
 void Engine::Tick()

--- a/source/engine/InputLayout.cpp
+++ b/source/engine/InputLayout.cpp
@@ -1,0 +1,62 @@
+#include "InputLayout.h"
+
+InputLayout::InputLayout()
+{
+}
+
+InputLayout::~InputLayout()
+{
+}
+
+void InputLayout::AppendElement(VertexStream vertexStream)
+{
+	D3D12_INPUT_ELEMENT_DESC element;
+	ZeroMemory(&element, sizeof(D3D12_INPUT_ELEMENT_DESC));
+
+	element.InputSlot = static_cast<UINT>(inputElementsList.size());
+	element.SemanticIndex = 0;
+	element.InstanceDataStepRate = 0;
+	element.InputSlotClass = D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA;
+	element.AlignedByteOffset = 0;
+
+	switch (vertexStream)
+	{
+	case VertexStream::Position:
+		element.SemanticName = "POSITION";
+		element.Format = DXGI_FORMAT_R32G32B32A32_FLOAT;
+		break;
+	case VertexStream::Color:
+		element.SemanticName = "COLOR";
+		element.Format = DXGI_FORMAT_R32G32B32A32_FLOAT;
+		break;
+	case VertexStream::Normal:
+		element.SemanticName = "NORMAL";
+		element.Format = DXGI_FORMAT_R32G32B32A32_FLOAT;
+		break;
+	case VertexStream::Tangent:
+		element.SemanticName = "TANGENT";
+		element.Format = DXGI_FORMAT_R32G32B32A32_FLOAT;
+		break;
+	case VertexStream::TexCoord:
+		element.SemanticName = "TEXCOORD";
+		element.Format = DXGI_FORMAT_R32G32_FLOAT;
+		break;
+	default:
+		element.SemanticName = "UNDEFINED";
+		element.Format = DXGI_FORMAT_UNKNOWN;
+		break;
+	}
+
+	inputElementsList.push_back(element);
+}
+
+D3D12_INPUT_LAYOUT_DESC InputLayout::GetInputLayoutDesc()
+{
+	D3D12_INPUT_LAYOUT_DESC inputLayout = {};
+	if (inputElementsList.size())
+	{
+		inputLayout.pInputElementDescs = inputElementsList.data();
+		inputLayout.NumElements = static_cast<UINT>(inputElementsList.size());
+	}
+	return inputLayout;
+}

--- a/source/engine/InputLayout.h
+++ b/source/engine/InputLayout.h
@@ -1,0 +1,33 @@
+#include <vector>
+#include <d3d12.h>
+
+enum class VertexStream
+{
+	Position,
+	Color,
+	Normal,
+	Tangent,
+	TexCoord
+};
+
+class InputLayout
+{
+public:
+	InputLayout();
+	~InputLayout();
+	template <typename T, typename... Types>
+	void AppendElementT(T firstArg, Types... restArgs)
+	{
+		AppendElement(firstArg);
+		AppendElementT(restArgs...);
+	}
+	template<typename T>
+	void AppendElementT(T firstArg)
+	{
+		AppendElement(firstArg);
+	}
+	D3D12_INPUT_LAYOUT_DESC GetInputLayoutDesc();
+private:
+	void AppendElement(VertexStream vertexStream);
+	std::vector<D3D12_INPUT_ELEMENT_DESC> inputElementsList;
+};

--- a/source/engine/Mesh.cpp
+++ b/source/engine/Mesh.cpp
@@ -1,7 +1,8 @@
 #include "Mesh.h"
 
-Mesh::Mesh(size_t vertexBufferIndex, D3D12_VERTEX_BUFFER_VIEW vertexBufferView, UINT vertexCount, const char* name)
-	: vertexBufferIndex(vertexBufferIndex), vertexBufferView(vertexBufferView), vertexCount(vertexCount)
+Mesh::Mesh(size_t vbIndexPosition, D3D12_VERTEX_BUFFER_VIEW vbvPosition, size_t vbIndexColor,
+	D3D12_VERTEX_BUFFER_VIEW vbvColor, UINT vertexCount, const char* name)
+	: vbIndexPosition(vbIndexPosition), vbvPosition(vbvPosition), vbIndexColor(vbIndexColor), vbvColor(vbvColor), vertexCount(vertexCount)
 {
 	strcpy_s(this->name, name);
 }

--- a/source/engine/Mesh.h
+++ b/source/engine/Mesh.h
@@ -6,12 +6,15 @@
 class Mesh
 {
 public:
-	Mesh(size_t vertexBufferIndex, D3D12_VERTEX_BUFFER_VIEW vertexBufferView, UINT vertexCount, const char* name);
-	D3D12_VERTEX_BUFFER_VIEW GetVertexBufferView() { return vertexBufferView; }
+	Mesh(size_t vbIndexPosition, D3D12_VERTEX_BUFFER_VIEW vbvPosition, size_t vbIndexColor, D3D12_VERTEX_BUFFER_VIEW vbvColor, UINT vertexCount, const char* name);
+	D3D12_VERTEX_BUFFER_VIEW GetPositionVertexBufferView() { return vbvPosition; }
+	D3D12_VERTEX_BUFFER_VIEW GetColorVertexBufferView() { return vbvColor; }
 	UINT GetVertexCount() { return vertexCount; }
 private:
-	size_t vertexBufferIndex;
+	size_t vbIndexPosition;
+	D3D12_VERTEX_BUFFER_VIEW vbvPosition;
+	size_t vbIndexColor;
+	D3D12_VERTEX_BUFFER_VIEW vbvColor;
 	CHAR name[32];
-	D3D12_VERTEX_BUFFER_VIEW vertexBufferView;
 	UINT vertexCount;
 };

--- a/source/engine/RenderContext.cpp
+++ b/source/engine/RenderContext.cpp
@@ -156,17 +156,17 @@ size_t RenderContext::CreateShaders(LPCWSTR shaderName)
 	return vertexShaders.size() - 1;
 }
 
-size_t RenderContext::CreatePipelineState(DeviceContext* deviceContext, size_t rootSignatureIndex, size_t shaderIndex)
+size_t RenderContext::CreatePipelineState(DeviceContext* deviceContext, size_t rootSignatureIndex, size_t shaderIndex, size_t inputLayoutIndex)
 {
 	OutputDebugString(L"CreatePipelineState\n");
 
 	// Create the Input Layout
-	inputLayout = new InputLayout();
-	inputLayout->AppendElementT(VertexStream::Position, VertexStream::Color);
+	//inputLayout = new InputLayout();
+	//inputLayout->AppendElementT(VertexStream::Position, VertexStream::Color);
 
 	// Describe and create the graphics pipeline state object (PSO).
 	D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-	psoDesc.InputLayout = inputLayout->GetInputLayoutDesc();
+	psoDesc.InputLayout = inputLayouts[inputLayoutIndex]->GetInputLayoutDesc();
 	psoDesc.pRootSignature = rootSignatures[rootSignatureIndex];
 	psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShaders[shaderIndex]);
 	psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShaders[shaderIndex]);
@@ -201,6 +201,13 @@ size_t RenderContext::CreateViewportAndScissorRect(DeviceContext* deviceContext)
 	OutputDebugString(L"CreateViewportAndScissorRect succeeded\n");
 
 	return viewports.size() - 1;
+}
+
+size_t RenderContext::CreateInputLayout()
+{
+	OutputDebugString(L"CreateInputLayout\n");
+	inputLayouts.push_back(new InputLayout());
+	return inputLayouts.size() - 1;
 }
 
 size_t RenderContext::CreateVertexBuffer(UINT numOfVertices, UINT numOfFloatsPerVertex, FLOAT* meshData)

--- a/source/engine/RenderContext.cpp
+++ b/source/engine/RenderContext.cpp
@@ -5,6 +5,7 @@
 #include "DepthBuffer.h"
 #include "Mesh.h"
 #include "VertexBuffer.h"
+#include "InputLayout.h"
 
 #include <Windows.h>
 #include <d3dcompiler.h>
@@ -159,16 +160,13 @@ size_t RenderContext::CreatePipelineState(DeviceContext* deviceContext, size_t r
 {
 	OutputDebugString(L"CreatePipelineState\n");
 
-	// Define the vertex input layout.
-	D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
-	{
-	    { "POSITION", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-	    { "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 16, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
-	};
+	// Create the Input Layout
+	inputLayout = new InputLayout();
+	inputLayout->AppendElementT(VertexStream::Position, VertexStream::Color);
 
 	// Describe and create the graphics pipeline state object (PSO).
 	D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-	psoDesc.InputLayout = { inputElementDescs, _countof(inputElementDescs) };
+	psoDesc.InputLayout = inputLayout->GetInputLayoutDesc();
 	psoDesc.pRootSignature = rootSignatures[rootSignatureIndex];
 	psoDesc.VS = CD3DX12_SHADER_BYTECODE(vertexShaders[shaderIndex]);
 	psoDesc.PS = CD3DX12_SHADER_BYTECODE(pixelShaders[shaderIndex]);
@@ -205,12 +203,12 @@ size_t RenderContext::CreateViewportAndScissorRect(DeviceContext* deviceContext)
 	return viewports.size() - 1;
 }
 
-size_t RenderContext::CreateVertexBuffer(UINT numOfVertices, FLOAT* meshData)
+size_t RenderContext::CreateVertexBuffer(UINT numOfVertices, UINT numOfFloatsPerVertex, FLOAT* meshData)
 {
 	OutputDebugString(L"CreateVertexBuffer\n");
 	
 	// Each vertex is: 4xFLOAT for position + 4xFLOAT for color
-	const UINT vbSizeInBytes = numOfVertices * 8 * sizeof(float);
+	const UINT vbSizeInBytes = numOfVertices * numOfFloatsPerVertex * sizeof(float);
 
 	// Note: using upload heaps to transfer static data like vert buffers is not 
 	// recommended. Every time the GPU needs it, the upload heap will be marshalled 
@@ -235,6 +233,67 @@ size_t RenderContext::CreateVertexBuffer(UINT numOfVertices, FLOAT* meshData)
 	vb->Unmap(0, nullptr);
 
 	return index;
+}
+
+size_t RenderContext::GenerateColors(float* data, size_t size, UINT numOfTriangles)
+{
+#define COLOR_1 153.0f / 255.0f, 202.0f / 255.0f, 34.0f / 255.0f, 1.0f
+#define COLOR_2 160.0f / 255.0f, 210.0f / 255.0f, 31.0f / 255.0f, 1.0f
+#define COLOR_3 173.0f / 255.0f, 223.0f / 255.0f, 44.0f / 255.0f, 1.0f
+
+#define COLOR_4 161.0f / 255.0f, 92.0f / 255.0f, 208.0f / 255.0f, 1.0f
+#define COLOR_5 166.0f / 255.0f, 96.0f / 255.0f, 213.0f / 255.0f, 1.0f
+#define COLOR_6 179.0f / 255.0f, 110.0f / 255.0f, 227.0f / 255.0f, 1.0f
+
+#define COLOR_7 191.0f / 255.0f, 111.0f / 255.0f, 29.0f / 255.0f, 1.0f
+#define COLOR_8 202.0f / 255.0f, 122.0f / 255.0f, 37.0f / 255.0f, 1.0f
+#define COLOR_9 225.0f / 255.0f, 152.0f / 255.0f, 58.0f / 255.0f, 1.0f
+
+#define COLOR_10 17.0f / 255.0f, 85.0f / 255.0f, 60.0f / 255.0f, 1.0f
+#define COLOR_11 39.0f / 255.0f, 112.0f / 255.0f, 85.0f / 255.0f, 1.0f
+#define COLOR_12 85.0f / 255.0f, 154.0f / 255.0f, 119.0f / 255.0f, 1.0f
+
+#define COLOR_13 86.0f / 255.0f, 126.0f / 255.0f, 145.0f / 255.0f, 1.0f
+#define COLOR_14 112.0f / 255.0f, 153.0f / 255.0f, 172.0f / 255.0f, 1.0f
+#define COLOR_15 138.0f / 255.0f, 180.0f / 255.0f, 200.0f / 255.0f, 1.0f
+
+#define COLOR_16 162.0f / 255.0f, 208.0f / 255.0f, 181.0f / 255.0f, 1.0f
+#define COLOR_17 170.0f / 255.0f, 214.0f / 255.0f, 188.0f / 255.0f, 1.0f
+#define COLOR_18 179.0f / 255.0f, 220.0f / 255.0f, 195.0f / 255.0f, 1.0f
+
+#define COLOR_19 24.0f / 255.0f, 207.0f / 255.0f, 45.0f / 255.0f, 1.0f
+#define COLOR_20 37.0f / 255.0f, 219.0f / 255.0f, 55.0f / 255.0f, 1.0f
+#define COLOR_21 51.0f / 255.0f, 231.0f / 255.0f, 66.0f / 255.0f, 1.0f
+
+#define COLOR_22 199.0f / 255.0f, 53.0f / 255.0f, 52.0f / 255.0f, 1.0f
+#define COLOR_23 208.0f / 255.0f, 64.0f / 255.0f, 62.0f / 255.0f, 1.0f
+#define COLOR_24 218.0f / 255.0f, 75.0f / 255.0f, 73.0f / 255.0f, 1.0f
+
+	// We need a buffer of the same size as the original mesh
+	float* meshPositionAndColor = new float[size];
+	float color[] = { COLOR_1, COLOR_2, COLOR_3,
+		COLOR_4, COLOR_5, COLOR_6,
+		COLOR_7, COLOR_8, COLOR_9,
+		COLOR_10, COLOR_11, COLOR_12,
+		COLOR_13, COLOR_14, COLOR_15,
+		COLOR_16, COLOR_17, COLOR_18,
+		COLOR_19, COLOR_20, COLOR_21,
+		COLOR_22, COLOR_23, COLOR_24
+	};
+	// Currently we handle seven colors, each color has 12 "elements" (three positions of four floats)
+	size_t colorOffset = (meshes.size() % 8) * 12;
+	for (int i = 0; i < size; i += 4)
+	{
+		// This loop copies vertices (not triangles) and adds color to them
+		// We don't need to copy the position, we just need to add the color
+		//memcpy(&meshPositionAndColor[i * 2], &data[i], 4 * sizeof(FLOAT));
+		const unsigned int colorIndex = (i / 12) % 3;
+		memcpy(&meshPositionAndColor[i], &color[(colorIndex * 4) + colorOffset], 4 * sizeof(FLOAT));
+	}
+
+	size_t meshIndex = CreateVertexBuffer(numOfTriangles * 3, 4, meshPositionAndColor);
+
+	return meshIndex;
 }
 
 size_t RenderContext::CreateEmptyTexture(UINT width, UINT height)
@@ -326,71 +385,22 @@ UINT RenderContext::CopyTexture(size_t cmdListIndex, size_t sourceIndex, size_t 
 	return 0;
 }
 
-size_t RenderContext::CreateMesh(float* data, size_t size, UINT numOfTriangles)
+size_t RenderContext::CreateMesh(size_t vbIndexPosition, size_t vbIndexColor)
 {
 	OutputDebugString(L"CreateMesh\n");
 
-#define COLOR_1 153.0f / 255.0f, 202.0f / 255.0f, 34.0f / 255.0f, 1.0f
-#define COLOR_2 160.0f / 255.0f, 210.0f / 255.0f, 31.0f / 255.0f, 1.0f
-#define COLOR_3 173.0f / 255.0f, 223.0f / 255.0f, 44.0f / 255.0f, 1.0f
+	D3D12_VERTEX_BUFFER_VIEW vbvPosition;
+	vbvPosition.BufferLocation = vertexBuffers[vbIndexPosition]->GetResource()->GetGPUVirtualAddress();
+	vbvPosition.StrideInBytes = 4 * sizeof(float);
+	vbvPosition.SizeInBytes = vertexBuffers[vbIndexPosition]->GetSizeInBytes();
 
-#define COLOR_4 161.0f / 255.0f, 92.0f / 255.0f, 208.0f / 255.0f, 1.0f
-#define COLOR_5 166.0f / 255.0f, 96.0f / 255.0f, 213.0f / 255.0f, 1.0f
-#define COLOR_6 179.0f / 255.0f, 110.0f / 255.0f, 227.0f / 255.0f, 1.0f
+	D3D12_VERTEX_BUFFER_VIEW vbvColor;
+	vbvColor.BufferLocation = vertexBuffers[vbIndexColor]->GetResource()->GetGPUVirtualAddress();
+	vbvColor.StrideInBytes = 4 * sizeof(float);
+	vbvColor.SizeInBytes = vertexBuffers[vbIndexColor]->GetSizeInBytes();
 
-#define COLOR_7 191.0f / 255.0f, 111.0f / 255.0f, 29.0f / 255.0f, 1.0f
-#define COLOR_8 202.0f / 255.0f, 122.0f / 255.0f, 37.0f / 255.0f, 1.0f
-#define COLOR_9 225.0f / 255.0f, 152.0f / 255.0f, 58.0f / 255.0f, 1.0f
-
-#define COLOR_10 17.0f / 255.0f, 85.0f / 255.0f, 60.0f / 255.0f, 1.0f
-#define COLOR_11 39.0f / 255.0f, 112.0f / 255.0f, 85.0f / 255.0f, 1.0f
-#define COLOR_12 85.0f / 255.0f, 154.0f / 255.0f, 119.0f / 255.0f, 1.0f
-
-#define COLOR_13 86.0f / 255.0f, 126.0f / 255.0f, 145.0f / 255.0f, 1.0f
-#define COLOR_14 112.0f / 255.0f, 153.0f / 255.0f, 172.0f / 255.0f, 1.0f
-#define COLOR_15 138.0f / 255.0f, 180.0f / 255.0f, 200.0f / 255.0f, 1.0f
-
-#define COLOR_16 162.0f / 255.0f, 208.0f / 255.0f, 181.0f / 255.0f, 1.0f
-#define COLOR_17 170.0f / 255.0f, 214.0f / 255.0f, 188.0f / 255.0f, 1.0f
-#define COLOR_18 179.0f / 255.0f, 220.0f / 255.0f, 195.0f / 255.0f, 1.0f
-
-#define COLOR_19 24.0f / 255.0f, 207.0f / 255.0f, 45.0f / 255.0f, 1.0f
-#define COLOR_20 37.0f / 255.0f, 219.0f / 255.0f, 55.0f / 255.0f, 1.0f
-#define COLOR_21 51.0f / 255.0f, 231.0f / 255.0f, 66.0f / 255.0f, 1.0f
-
-#define COLOR_22 199.0f / 255.0f, 53.0f / 255.0f, 52.0f / 255.0f, 1.0f
-#define COLOR_23 208.0f / 255.0f, 64.0f / 255.0f, 62.0f / 255.0f, 1.0f
-#define COLOR_24 218.0f / 255.0f, 75.0f / 255.0f, 73.0f / 255.0f, 1.0f
-
-	// Basically, each vertex has 4 floats, and we need to add 4 more for the color
-	float* meshPositionAndColor = new float[size * 2];
-	float color[] = { COLOR_1, COLOR_2, COLOR_3,
-		COLOR_4, COLOR_5, COLOR_6,
-		COLOR_7, COLOR_8, COLOR_9,
-		COLOR_10, COLOR_11, COLOR_12,
-		COLOR_13, COLOR_14, COLOR_15,
-		COLOR_16, COLOR_17, COLOR_18,
-		COLOR_19, COLOR_20, COLOR_21,
-		COLOR_22, COLOR_23, COLOR_24
-	};
-	size_t colorOffset = (meshes.size() % 8) * 12;
-	for (int i = 0; i < size; i += 4)
-	{
-		// This loop copies vertices (not triangles) and adds color to them
-		memcpy(&meshPositionAndColor[i * 2], &data[i], 4 * sizeof(FLOAT));
-		const unsigned int colorIndex = (i / 12) % 3;
-		memcpy(&meshPositionAndColor[i * 2 + 4], &color[(colorIndex * 4) + colorOffset], 4 * sizeof(FLOAT));
-	}
-
-	size_t meshIndex = CreateVertexBuffer(numOfTriangles * 3, meshPositionAndColor);
-	
-	D3D12_VERTEX_BUFFER_VIEW vbv;
-	vbv.BufferLocation = vertexBuffers[meshIndex]->GetResource()->GetGPUVirtualAddress();
-	vbv.StrideInBytes = 8 * sizeof(float);
-	vbv.SizeInBytes = vertexBuffers[meshIndex]->GetSizeInBytes();
-
-	UINT vertexCount = vertexBuffers[meshIndex]->GetNumOfVertices() * 3;
-	meshes.push_back(new Mesh(meshIndex, vbv, vertexCount, "DefalutMesh"));
+	UINT vertexCount = vertexBuffers[vbIndexPosition]->GetNumOfVertices() * 3;
+	meshes.push_back(new Mesh(vbIndexPosition, vbvPosition, vbIndexColor, vbvColor, vertexCount, "DefalutMesh"));
 
 	return 0;
 }
@@ -457,8 +467,12 @@ void RenderContext::SetupRenderPass(size_t cmdListIndex, size_t psoIndex, size_t
 void RenderContext::BindGeometry(size_t cmdListIndex, size_t meshIndex)
 {
 	commandLists[cmdListIndex]->GetCommandList()->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-	auto vbv = meshes[meshIndex]->GetVertexBufferView();
-	commandLists[cmdListIndex]->GetCommandList()->IASetVertexBuffers(0, 1, &vbv);
+	D3D12_VERTEX_BUFFER_VIEW vbvPosition[] =
+	{
+		meshes[meshIndex]->GetPositionVertexBufferView(),
+		meshes[meshIndex]->GetColorVertexBufferView()
+	};
+	commandLists[cmdListIndex]->GetCommandList()->IASetVertexBuffers(0, 2, vbvPosition);
 }
 
 void RenderContext::TransitionTo(size_t cmdListIndex, size_t textureId, D3D12_RESOURCE_STATES state)

--- a/source/engine/RenderContext.cpp
+++ b/source/engine/RenderContext.cpp
@@ -210,7 +210,7 @@ size_t RenderContext::CreateInputLayout()
 	return inputLayouts.size() - 1;
 }
 
-size_t RenderContext::CreateVertexBuffer(UINT numOfVertices, UINT numOfFloatsPerVertex, FLOAT* meshData)
+size_t RenderContext::CreateVertexBuffer(UINT numOfVertices, UINT numOfFloatsPerVertex, FLOAT* meshData, const CHAR* name)
 {
 	OutputDebugString(L"CreateVertexBuffer\n");
 	
@@ -227,7 +227,15 @@ size_t RenderContext::CreateVertexBuffer(UINT numOfVertices, UINT numOfFloatsPer
 	ID3D12Resource* vertexBuffer;
 	D3D12_HEAP_FLAGS heapFlags = D3D12_HEAP_FLAG_NONE;
 	deviceContext.CreateUploadResource(heapFlags, &resourceDesc, initResourceState, IID_PPV_ARGS(& vertexBuffer));
-	vertexBuffers.push_back(new VertexBuffer(vertexBuffer, vbSizeInBytes, numOfVertices, "VB_Default"));
+
+	CHAR tempName[64];
+	snprintf(tempName, sizeof(tempName), "VB_%s", name);
+	WCHAR wName[64];
+	size_t numOfCharsConverted;;
+	mbstowcs_s(&numOfCharsConverted, wName, tempName, 32);
+	vertexBuffer->SetName(wName);
+
+	vertexBuffers.push_back(new VertexBuffer(vertexBuffer, vbSizeInBytes, numOfVertices, tempName));
 	
 	// Copy the triangle data to the vertex buffer.
 	UINT8* pVertexDataBegin;
@@ -242,7 +250,7 @@ size_t RenderContext::CreateVertexBuffer(UINT numOfVertices, UINT numOfFloatsPer
 	return index;
 }
 
-size_t RenderContext::GenerateColors(float* data, size_t size, UINT numOfTriangles)
+size_t RenderContext::GenerateColors(float* data, size_t size, UINT numOfTriangles, const CHAR* name)
 {
 #define COLOR_1 153.0f / 255.0f, 202.0f / 255.0f, 34.0f / 255.0f, 1.0f
 #define COLOR_2 160.0f / 255.0f, 210.0f / 255.0f, 31.0f / 255.0f, 1.0f
@@ -298,7 +306,10 @@ size_t RenderContext::GenerateColors(float* data, size_t size, UINT numOfTriangl
 		memcpy(&meshPositionAndColor[i], &color[(colorIndex * 4) + colorOffset], 4 * sizeof(FLOAT));
 	}
 
-	size_t meshIndex = CreateVertexBuffer(numOfTriangles * 3, 4, meshPositionAndColor);
+	CHAR tempName[64];
+	snprintf(tempName, sizeof(tempName), "COLOR_%s", name);
+
+	size_t meshIndex = CreateVertexBuffer(numOfTriangles * 3, 4, meshPositionAndColor, tempName);
 
 	return meshIndex;
 }
@@ -392,7 +403,7 @@ UINT RenderContext::CopyTexture(size_t cmdListIndex, size_t sourceIndex, size_t 
 	return 0;
 }
 
-size_t RenderContext::CreateMesh(size_t vbIndexPosition, size_t vbIndexColor)
+size_t RenderContext::CreateMesh(size_t vbIndexPosition, size_t vbIndexColor, const CHAR* name)
 {
 	OutputDebugString(L"CreateMesh\n");
 
@@ -407,7 +418,7 @@ size_t RenderContext::CreateMesh(size_t vbIndexPosition, size_t vbIndexColor)
 	vbvColor.SizeInBytes = vertexBuffers[vbIndexColor]->GetSizeInBytes();
 
 	UINT vertexCount = vertexBuffers[vbIndexPosition]->GetNumOfVertices() * 3;
-	meshes.push_back(new Mesh(vbIndexPosition, vbvPosition, vbIndexColor, vbvColor, vertexCount, "DefalutMesh"));
+	meshes.push_back(new Mesh(vbIndexPosition, vbvPosition, vbIndexColor, vbvColor, vertexCount, name));
 
 	return 0;
 }

--- a/source/engine/RenderContext.h
+++ b/source/engine/RenderContext.h
@@ -25,8 +25,10 @@ public:
 	void CreateRenderTargetFromBackBuffer(DeviceContext* deviceContext);
 	size_t CreateRootSignature(DeviceContext* deviceContext);
 	size_t CreateShaders(LPCWSTR shaderName);
-	size_t CreatePipelineState(DeviceContext* deviceContext, size_t rootSignatureIndex, size_t shaderIndex);
+	size_t CreatePipelineState(DeviceContext* deviceContext, size_t rootSignatureIndex, size_t shaderIndex, size_t inputLayoutIndex);
 	size_t CreateViewportAndScissorRect(DeviceContext* deviceContext);
+	size_t CreateInputLayout();
+	InputLayout* GetInputLayout(size_t index) { return inputLayouts[index]; }
 	void CreateIndexBuffer(DeviceContext* deviceContext);
 	void CreateConstantBuffer(DeviceContext* deviceContext);
 	void CreateSampler(DeviceContext* deviceContext);
@@ -70,7 +72,6 @@ private:
 	DescriptorHeap rtvHeap;
 	DescriptorHeap dsvHeap;
 	DescriptorHeap cbvSrvUavHeap;
-	InputLayout* inputLayout;
 	ID3D12Resource* backBuffer[2];
 private:
 	std::vector<RenderTarget*> renderTargets;
@@ -85,4 +86,5 @@ private:
 	std::vector<ID3D12PipelineState*> pipelineStates;
 	std::vector<CD3DX12_VIEWPORT> viewports;
 	std::vector<CD3DX12_RECT> scissorRects;
+	std::vector<InputLayout*> inputLayouts;
 };

--- a/source/engine/RenderContext.h
+++ b/source/engine/RenderContext.h
@@ -41,15 +41,15 @@ public:
 	// High Level
 	size_t CreateRenderTarget();
 	size_t CreateDepthBuffer();
-	size_t CreateMesh(size_t vbIndexPosition, size_t vbIndexColor);
+	size_t CreateMesh(size_t vbIndexPosition, size_t vbIndexColor, const CHAR* name);
 	// Textures
 	size_t CreateEmptyTexture(UINT width, UINT height);
 	size_t CreateDepthTexture(UINT width, UINT height, const CHAR* name);
 	size_t CreateRenderTargetTexture(UINT width, UINT height, const CHAR* name);
 	UINT CopyTexture(size_t cmdListIndex, size_t sourceIndex, size_t destIndex);
 	// Geometry
-	size_t CreateVertexBuffer(UINT numOfVertices, UINT numOfFloatsPerVertex, FLOAT* meshData);
-	size_t GenerateColors(float* data, size_t size, UINT numOfTriangles);
+	size_t CreateVertexBuffer(UINT numOfVertices, UINT numOfFloatsPerVertex, FLOAT* meshData, const CHAR* name);
+	size_t GenerateColors(float* data, size_t size, UINT numOfTriangles, const CHAR* name);
 	// Constants
 	void SetInlineConstants(size_t cmdListIndex, UINT numOfConstants, void* data);
 	// Binding

--- a/source/engine/RenderContext.h
+++ b/source/engine/RenderContext.h
@@ -14,6 +14,7 @@ class DepthBuffer;
 class Texture;
 class VertexBuffer;
 class Mesh;
+class InputLayout;
 
 class RenderContext
 {
@@ -38,14 +39,15 @@ public:
 	// High Level
 	size_t CreateRenderTarget();
 	size_t CreateDepthBuffer();
-	size_t CreateMesh(float* data, size_t size, UINT numOfTriangles);
+	size_t CreateMesh(size_t vbIndexPosition, size_t vbIndexColor);
 	// Textures
 	size_t CreateEmptyTexture(UINT width, UINT height);
 	size_t CreateDepthTexture(UINT width, UINT height, const CHAR* name);
 	size_t CreateRenderTargetTexture(UINT width, UINT height, const CHAR* name);
 	UINT CopyTexture(size_t cmdListIndex, size_t sourceIndex, size_t destIndex);
 	// Geometry
-	size_t CreateVertexBuffer(UINT numOfVertices, FLOAT* meshData);
+	size_t CreateVertexBuffer(UINT numOfVertices, UINT numOfFloatsPerVertex, FLOAT* meshData);
+	size_t GenerateColors(float* data, size_t size, UINT numOfTriangles);
 	// Constants
 	void SetInlineConstants(size_t cmdListIndex, UINT numOfConstants, void* data);
 	// Binding
@@ -68,6 +70,7 @@ private:
 	DescriptorHeap rtvHeap;
 	DescriptorHeap dsvHeap;
 	DescriptorHeap cbvSrvUavHeap;
+	InputLayout* inputLayout;
 	ID3D12Resource* backBuffer[2];
 private:
 	std::vector<RenderTarget*> renderTargets;

--- a/source/engine/RenderGraph.cpp
+++ b/source/engine/RenderGraph.cpp
@@ -32,6 +32,7 @@ void RenderGraph::Initialize()
 {
 	for (RenderPass* renderPass : renderPasses)
 	{
+		renderPass->ConfigurePipelineState();
 		renderPass->AutomaticPrepare();
 		renderPass->Prepare();
 	}

--- a/source/engine/RenderPass.cpp
+++ b/source/engine/RenderPass.cpp
@@ -1,5 +1,6 @@
 #include "RenderPass.h"
 #include "RenderContext.h"
+#include "InputLayout.h"
 
 #ifdef DEBUG
 #define USE_PIX
@@ -25,7 +26,7 @@ void RenderPass::AutomaticPrepare()
 	{
 		rootSignatureIndex = renderContext.CreateRootSignature(&deviceContext);
 		shaderIndex = renderContext.CreateShaders(shaderSourceFileName);
-		pipelineStateIndex = renderContext.CreatePipelineState(&deviceContext, rootSignatureIndex, shaderIndex);
+		pipelineStateIndex = renderContext.CreatePipelineState(&deviceContext, rootSignatureIndex, shaderIndex, inputLayoutIndex);
 		viewportAndScissorsIndex = renderContext.CreateViewportAndScissorRect(&deviceContext);
 	}
 

--- a/source/engine/RenderPass.h
+++ b/source/engine/RenderPass.h
@@ -16,6 +16,7 @@ public:
 	};
 	RenderPass(PCWSTR name, RenderPass::Type type);
 	~RenderPass();
+	virtual void ConfigurePipelineState() = 0;
 	void AutomaticPrepare();
 	virtual void Prepare();
 	virtual void Update();
@@ -28,6 +29,7 @@ protected:
 	RenderPass::Type type;
 	size_t shaderIndex;
 	size_t rootSignatureIndex;
+	size_t inputLayoutIndex;
 	size_t pipelineStateIndex;
 	size_t viewportAndScissorsIndex;
 	size_t commandListIndex;

--- a/source/engine/TestPass.cpp
+++ b/source/engine/TestPass.cpp
@@ -3,6 +3,7 @@
 #include "RenderContext.h"
 #include "DeviceContext.h"
 #include "WindowContext.h"
+#include "InputLayout.h"
 #include "camera/PerspectiveCamera.h"
 #include "camera/OrthographicCamera.h"
 #include "camera/Arcball.h"
@@ -43,6 +44,13 @@ TestPass::~TestPass()
 #else
 	delete orthoCamera;
 #endif
+}
+
+void TestPass::ConfigurePipelineState()
+{
+	// Pre-AutomaticPrepare Procedure
+	inputLayoutIndex = renderContext.CreateInputLayout();
+	renderContext.GetInputLayout(inputLayoutIndex)->AppendElementT(VertexStream::Position, VertexStream::Color);
 }
 
 void TestPass::Prepare()

--- a/source/engine/TestPass.h
+++ b/source/engine/TestPass.h
@@ -16,6 +16,7 @@ class TestPass : public RenderPass
 public:
 	TestPass();
 	~TestPass();
+	void ConfigurePipelineState() override;
 	void Prepare() override;
 	void Update() override;
 	void Execute() override;


### PR DESCRIPTION
The whole point of this feature is to add flexibility when binding geometry data. Shadow Map Render Pass only requires the position, while G-Buffer requires all the geometry data. Now, you can simply state which components of the mesh you need, and it will be automatically bound, by creating dynamic Input Layout and bind properly. The Drawing is not done automatically though, this was solved by overriding the Draw function, but it should be good enough for now.