### PR TITLE
[FIX] ImGui messed up after scene reload

### DIFF
--- a/source/engine/bind/DescriptorHeap.cpp
+++ b/source/engine/bind/DescriptorHeap.cpp
@@ -52,9 +52,9 @@ CD3DX12_CPU_DESCRIPTOR_HANDLE DescriptorHeap::Allocate(HeapPartition partition)
 
 void DescriptorHeap::Allocate(D3D12_CPU_DESCRIPTOR_HANDLE* outCpu, D3D12_GPU_DESCRIPTOR_HANDLE* outGpu)
 {
-	Allocate(HeapPartition::DYNAMIC);
-	*outCpu = Get(HeapPartition::DYNAMIC, staticCapacity + dynamicSize - 1);
-	*outGpu = GetGPU(HeapPartition::DYNAMIC, staticCapacity + dynamicSize - 1);
+	Allocate(HeapPartition::STATIC);
+	*outCpu = Get(HeapPartition::STATIC, staticSize - 1);
+	*outGpu = GetGPU(HeapPartition::STATIC, staticSize - 1);
 	// Is this a correct?
 	//++dynamicSize;
 }

--- a/source/engine/bind/DescriptorHeap.cpp
+++ b/source/engine/bind/DescriptorHeap.cpp
@@ -77,5 +77,4 @@ UINT DescriptorHeap::Size()
 void DescriptorHeap::Reset()
 {
 	size = heapType == D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV ? 4 : 0;
-	freeList = std::stack<uint32_t>();
 }

--- a/source/engine/bind/DescriptorHeap.h
+++ b/source/engine/bind/DescriptorHeap.h
@@ -20,7 +20,6 @@ public:
 	ID3D12DescriptorHeap* GetHeap() { return heap; }
 	void Reset();
 private:
-	std::stack<uint32_t> freeList;
 	D3D12_DESCRIPTOR_HEAP_TYPE heapType;
 	ID3D12DescriptorHeap* heap;
 	UINT descriptorSize;

--- a/source/engine/bind/DescriptorHeap.h
+++ b/source/engine/bind/DescriptorHeap.h
@@ -6,20 +6,24 @@
 
 class DeviceContext;
 
-constexpr uint32_t MAX_NUM_OF_DESCRIPTORS = 100;
-constexpr uint32_t MAX_NUM_OF_STATIC_DESCRIPTORS = 4;
+constexpr uint32_t MAX_NUM_OF_DESCRIPTORS = 90;
+constexpr uint32_t MAX_NUM_OF_STATIC_DESCRIPTORS = 10;
 
 class DescriptorHeap
 {
 public:
+	enum HeapPartition
+	{
+		STATIC,
+		DYNAMIC
+	};
 	void Create(D3D12_DESCRIPTOR_HEAP_TYPE type, DeviceContext* deviceContext);
-	CD3DX12_CPU_DESCRIPTOR_HANDLE Allocate();
+	CD3DX12_CPU_DESCRIPTOR_HANDLE Allocate(HeapPartition partition);
 	void Allocate(D3D12_CPU_DESCRIPTOR_HANDLE* outCpu, D3D12_GPU_DESCRIPTOR_HANDLE* outGpu);
 	void Free(D3D12_CPU_DESCRIPTOR_HANDLE cpu, D3D12_GPU_DESCRIPTOR_HANDLE gpu);
-	D3D12_CPU_DESCRIPTOR_HANDLE Get(size_t index) const;
-	D3D12_GPU_DESCRIPTOR_HANDLE GetGPU(size_t index) const;
-	uint32_t StaticSize() { return staticSize; }
-	uint32_t DynamicSize() { return dynamicSize; }
+	D3D12_CPU_DESCRIPTOR_HANDLE Get(HeapPartition partition, size_t index) const;
+	D3D12_GPU_DESCRIPTOR_HANDLE GetGPU(HeapPartition partition, size_t index) const;
+	uint32_t Size(HeapPartition partition) { return partition == STATIC ? staticSize : staticCapacity + dynamicSize; }
 	UINT GetDescriptorSize() { return descriptorSize; }
 	ID3D12DescriptorHeap* GetHeap() { return heap; }
 	void Reset();

--- a/source/engine/bind/DescriptorHeap.h
+++ b/source/engine/bind/DescriptorHeap.h
@@ -6,6 +6,9 @@
 
 class DeviceContext;
 
+constexpr uint32_t MAX_NUM_OF_DESCRIPTORS = 100;
+constexpr uint32_t MAX_NUM_OF_STATIC_DESCRIPTORS = 4;
+
 class DescriptorHeap
 {
 public:
@@ -15,13 +18,17 @@ public:
 	void Free(D3D12_CPU_DESCRIPTOR_HANDLE cpu, D3D12_GPU_DESCRIPTOR_HANDLE gpu);
 	D3D12_CPU_DESCRIPTOR_HANDLE Get(size_t index) const;
 	D3D12_GPU_DESCRIPTOR_HANDLE GetGPU(size_t index) const;
-	UINT Size();
+	uint32_t StaticSize() { return staticSize; }
+	uint32_t DynamicSize() { return dynamicSize; }
 	UINT GetDescriptorSize() { return descriptorSize; }
 	ID3D12DescriptorHeap* GetHeap() { return heap; }
 	void Reset();
 private:
+	uint32_t staticCapacity = MAX_NUM_OF_STATIC_DESCRIPTORS;
+	uint32_t dynamicCapacity = MAX_NUM_OF_DESCRIPTORS - MAX_NUM_OF_STATIC_DESCRIPTORS;
 	D3D12_DESCRIPTOR_HEAP_TYPE heapType;
 	ID3D12DescriptorHeap* heap;
 	UINT descriptorSize;
-	UINT size;
+	uint32_t staticSize;
+	uint32_t dynamicSize;
 };

--- a/source/engine/renderer/RenderContext.cpp
+++ b/source/engine/renderer/RenderContext.cpp
@@ -133,7 +133,7 @@ HRenderTarget RenderContext::CreateRenderTarget(const char* name, RenderTargetFo
 		textures[texture.Index()]->GetResource(), nullptr, rtvHeap.Allocate());
 
 	renderTargets.push_back(new RenderTarget(
-		width, height, texture.Index(), rtvHeap.Size() - 1, name, dxgiFormat));
+		width, height, texture.Index(), rtvHeap.DynamicSize() - 1, name, dxgiFormat));
 
 	return HRenderTarget(renderTargets.size() - 1);
 }
@@ -145,7 +145,7 @@ HDepthBuffer RenderContext::CreateDepthBuffer()
 	HTexture depth = CreateDepthTexture(windowContext.GetWidth(), windowContext.GetHeight(), "DB_Custom_Texture");
 	deviceContext.GetDevice()->CreateDepthStencilView(textures[depth.Index()]->GetResource(), nullptr, dsvHeap.Allocate());
 
-	depthBuffers.push_back(new DepthBuffer(windowContext.GetWidth(), windowContext.GetHeight(), depth.Index(), dsvHeap.Size() - 1, "DB_Custom"));
+	depthBuffers.push_back(new DepthBuffer(windowContext.GetWidth(), windowContext.GetHeight(), depth.Index(), dsvHeap.DynamicSize() - 1, "DB_Custom"));
 
 	return HDepthBuffer(depthBuffers.size() - 1);
 }
@@ -168,7 +168,7 @@ void RenderContext::CreateRenderTargetFromBackBuffer(DeviceContext* deviceContex
 
 		deviceContext->GetDevice()->CreateRenderTargetView(backBuffer[i], nullptr, rtvHeap.Allocate());
 		renderTargets.push_back(new RenderTarget(windowContext.GetWidth(), windowContext.GetHeight(), textures.size() - 1,
-			rtvHeap.Size() - 1, "RT_BackBuffer", backBuffer[i]->GetDesc().Format));
+			rtvHeap.DynamicSize() - 1, "RT_BackBuffer", backBuffer[i]->GetDesc().Format));
 		OutputDebugString(L"CreateRenderTargetFromBackBuffer succeeded\n");
 	}
 }
@@ -656,7 +656,7 @@ UINT RenderContext::CreateShaderResourceView(HTexture& textureHandle)
 	srvDesc.Texture2D.MipLevels = 1;
 
 	auto descriptorHandle = cbvSrvUavHeap.Allocate();
-	auto offset = cbvSrvUavHeap.Size() - 1;
+	auto offset = cbvSrvUavHeap.DynamicSize() - 1;
 
 	deviceContext.GetDevice()->CreateShaderResourceView(
 		textures[textureHandle.Index()]->GetResource(),            // Your texture resource
@@ -675,7 +675,7 @@ UINT RenderContext::CreateShaderResourceView(ID3D12Resource* resource, bool isDe
 	srvDesc.Texture2D.MipLevels = 1;
 
 	auto descriptorHandle = cbvSrvUavHeap.Allocate();
-	auto offset = cbvSrvUavHeap.Size() - 1;
+	auto offset = cbvSrvUavHeap.DynamicSize() - 1;
 
 	deviceContext.GetDevice()->CreateShaderResourceView(
 		resource,            // Your texture resource

--- a/source/engine/renderer/RenderContext.h
+++ b/source/engine/renderer/RenderContext.h
@@ -55,7 +55,7 @@ public:
 	void CreateMesh(HVertexBuffer vbIndexPosition, HVertexBuffer vbIndexColor, HVertexBuffer vbIndexTexture, const CHAR* name);
 	void CreateTexture(UINT width, UINT height, BYTE* data, const CHAR* name);
 	UINT CreateShaderResourceView(HTexture& textureHandle);
-	UINT CreateShaderResourceView(ID3D12Resource* resource, bool isDepth);
+	UINT CreateShaderResourceView(ID3D12Resource* resource, bool isDepth, bool isStatic);
 	void UploadTextureToBuffer(UINT width, UINT height, BYTE* data, HBuffer& bufferHandle);
 	void FillTextureUploadBuffer(UINT width, UINT height, HBuffer& bufferHandle);
 	void LoadTextureFromFile(UINT width, UINT height, HBuffer& bufferHandle);

--- a/source/engine/renderer/passes/ImGuiPass.cpp
+++ b/source/engine/renderer/passes/ImGuiPass.cpp
@@ -202,7 +202,7 @@ void ImGuiPass::Execute()
 	auto finalTexture = renderContext.GetTexture(colorRenderTarget);
 	auto finalFinalTexture = renderContext.GetTexture(finalTexture);
 	renderContext.TransitionTo(commandList, finalTexture, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
-	auto srvHandleGPU = renderContext.GetSrvHeap().GetGPU(DescriptorHeap::HeapPartition::DYNAMIC, finalFinalTexture->GetSrvDescriptorIndex());
+	auto srvHandleGPU = renderContext.GetSrvHeap().GetGPU(DescriptorHeap::HeapPartition::STATIC, finalFinalTexture->GetSrvDescriptorIndex());
 	ImTextureID textureID = (ImTextureID)srvHandleGPU.ptr;
 	ImVec2 size = ImGui::GetContentRegionAvail();
 	ImGui::Image(textureID, size);

--- a/source/engine/renderer/passes/ImGuiPass.cpp
+++ b/source/engine/renderer/passes/ImGuiPass.cpp
@@ -202,7 +202,7 @@ void ImGuiPass::Execute()
 	auto finalTexture = renderContext.GetTexture(colorRenderTarget);
 	auto finalFinalTexture = renderContext.GetTexture(finalTexture);
 	renderContext.TransitionTo(commandList, finalTexture, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
-	auto srvHandleGPU = renderContext.GetSrvHeap().GetGPU(finalFinalTexture->GetSrvDescriptorIndex());
+	auto srvHandleGPU = renderContext.GetSrvHeap().GetGPU(DescriptorHeap::HeapPartition::DYNAMIC, finalFinalTexture->GetSrvDescriptorIndex());
 	ImTextureID textureID = (ImTextureID)srvHandleGPU.ptr;
 	ImVec2 size = ImGui::GetContentRegionAvail();
 	ImGui::Image(textureID, size);


### PR DESCRIPTION
The resolution was pretty complex, had to update the Descriptor Heap to actually have two parts, one for Static allocation (meaning they will survive the scene reloading) and one for Dynamic allocations (those are for asset textures and will not survive scene reloading). Not sure if this is like the best solution ever, but it works and is clean and will allow me to move forward.