### PR TITLE
Add shadow mapping support

### DIFF
--- a/source/engine/asset/Mesh.cpp
+++ b/source/engine/asset/Mesh.cpp
@@ -4,9 +4,11 @@
 
 Mesh::Mesh(size_t vbIndexPosition, D3D12_VERTEX_BUFFER_VIEW vbvPosition, size_t vbIndexColor,
 	D3D12_VERTEX_BUFFER_VIEW vbvColor, size_t vbIndexTexture, D3D12_VERTEX_BUFFER_VIEW vbvTexture,
-	size_t vbIndexNormals, D3D12_VERTEX_BUFFER_VIEW vbvNormals, UINT vertexCount, const char* name)
+	size_t vbIndexNormals, D3D12_VERTEX_BUFFER_VIEW vbvNormals, UINT vertexCount,
+	DirectX::SimpleMath::Vector3 localMin, DirectX::SimpleMath::Vector3 localMax, const char* name)
 	: vbIndexPosition(vbIndexPosition), vbvPosition(vbvPosition), vbIndexColor(vbIndexColor), vbvColor(vbvColor),
-	vbIndexTexture(vbIndexTexture), vbvTexture(vbvTexture), vbIndexNormals(vbIndexNormals), vbvNormals(vbvNormals), vertexCount(vertexCount)
+	vbIndexTexture(vbIndexTexture), vbvTexture(vbvTexture), vbIndexNormals(vbIndexNormals), vbvNormals(vbvNormals),
+	vertexCount(vertexCount), localMin(localMin), localMax(localMax)
 {
 	strcpy_s(this->name, name);
 }

--- a/source/engine/asset/Mesh.h
+++ b/source/engine/asset/Mesh.h
@@ -2,13 +2,14 @@
 
 #include <Windows.h>
 #include <d3d12.h>
+#include "../../externals/SimpleMath/SimpleMath.h"
 
 class Mesh
 {
 public:
 	Mesh(size_t vbIndexPosition, D3D12_VERTEX_BUFFER_VIEW vbvPosition, size_t vbIndexColor, D3D12_VERTEX_BUFFER_VIEW vbvColor,
 		size_t vbIndexTexture, D3D12_VERTEX_BUFFER_VIEW vbvTexture, size_t vbIndexNormals, D3D12_VERTEX_BUFFER_VIEW vbvNormals,
-		UINT vertexCount, const char* name);
+		UINT vertexCount, DirectX::SimpleMath::Vector3 localMin, DirectX::SimpleMath::Vector3 localMax, const char* name);
 	~Mesh();
 	D3D12_VERTEX_BUFFER_VIEW GetPositionVertexBufferView() { return vbvPosition; }
 	D3D12_VERTEX_BUFFER_VIEW GetColorVertexBufferView() { return vbvColor; }
@@ -16,6 +17,8 @@ public:
 	D3D12_VERTEX_BUFFER_VIEW GetNormalsVertexBufferView() { return vbvNormals; }
 	UINT GetVertexCount() { return vertexCount; }
 	const char* GetName() { return name; }
+	DirectX::SimpleMath::Vector3 GetLocalMin() const { return localMin; }
+	DirectX::SimpleMath::Vector3 GetLocalMax() const { return localMax; }
 private:
 	size_t vbIndexPosition;
 	D3D12_VERTEX_BUFFER_VIEW vbvPosition;
@@ -27,4 +30,6 @@ private:
 	D3D12_VERTEX_BUFFER_VIEW vbvNormals;
 	CHAR name[32];
 	UINT vertexCount;
+	DirectX::SimpleMath::Vector3 localMin;
+	DirectX::SimpleMath::Vector3 localMax;
 };

--- a/source/engine/bind/PipelineState.cpp
+++ b/source/engine/bind/PipelineState.cpp
@@ -31,6 +31,29 @@ void PipelineState::Create(const D3D12_INPUT_LAYOUT_DESC& inputLayoutDesc, ID3D1
 	type = Type::Graphics;
 }
 
+void PipelineState::CreateDepthOnly(const D3D12_INPUT_LAYOUT_DESC& inputLayoutDesc, ID3D12RootSignature* rootSignature,
+	const D3D12_SHADER_BYTECODE& vertexShader)
+{
+	D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+	psoDesc.InputLayout = inputLayoutDesc;
+	psoDesc.pRootSignature = rootSignature;
+	psoDesc.VS = vertexShader;
+	psoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+	psoDesc.RasterizerState.CullMode = D3D12_CULL_MODE_BACK;
+	psoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+	psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
+	psoDesc.SampleMask = UINT_MAX;
+	psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+	psoDesc.NumRenderTargets = 0;
+	psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
+	psoDesc.SampleDesc.Count = 1;
+
+	HRESULT hr = deviceContext.GetDevice()->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&pipelineState));
+	DX_TRY(hr, "CreateGraphicsPipelineState", "There was an error during Depth Only PSO creation.");
+	pipelineState->SetName(L"Depth Only Pipeline State");
+	type = Type::Graphics;
+}
+
 void PipelineState::Create(ID3D12RootSignature* rootSignature, const D3D12_SHADER_BYTECODE& computeShader)
 {
 	D3D12_COMPUTE_PIPELINE_STATE_DESC psoDesc = {};

--- a/source/engine/bind/PipelineState.h
+++ b/source/engine/bind/PipelineState.h
@@ -15,6 +15,8 @@ public:
 	};
 	void Create(const D3D12_INPUT_LAYOUT_DESC& inputLayoutDesc, ID3D12RootSignature* rootSignature,
 		const D3D12_SHADER_BYTECODE& vertexShader, const D3D12_SHADER_BYTECODE& pixelShader, DXGI_FORMAT renderTargetFrormat);
+	void CreateDepthOnly(const D3D12_INPUT_LAYOUT_DESC& inputLayoutDesc, ID3D12RootSignature* rootSignature,
+		const D3D12_SHADER_BYTECODE& vertexShader);
 	void Create(ID3D12RootSignature* rootSignature, const D3D12_SHADER_BYTECODE& computeShader);
 	ID3D12PipelineState* Get() { return pipelineState; }
 	bool IsGrpahics() const { return type == Type::Graphics; }

--- a/source/engine/core/DepthBuffer.h
+++ b/source/engine/core/DepthBuffer.h
@@ -6,6 +6,8 @@ public:
 	DepthBuffer(UINT width, UINT height, size_t textureIndex, size_t dsvDescriptorIndex, const char* name);
 	size_t GetDescriptorIndex();
 	size_t GetTextureIndex() const { return textureIndex; }
+	UINT GetWidth() const { return width; }
+	UINT GetHeight() const { return height; }
 private:
 	char name[32];
 	size_t textureIndex;

--- a/source/engine/core/DepthBuffer.h
+++ b/source/engine/core/DepthBuffer.h
@@ -5,6 +5,7 @@ class DepthBuffer
 public:
 	DepthBuffer(UINT width, UINT height, size_t textureIndex, size_t dsvDescriptorIndex, const char* name);
 	size_t GetDescriptorIndex();
+	size_t GetTextureIndex() const { return textureIndex; }
 private:
 	char name[32];
 	size_t textureIndex;

--- a/source/engine/core/DeviceContext.cpp
+++ b/source/engine/core/DeviceContext.cpp
@@ -245,17 +245,24 @@ void DeviceContext::CreateGpuResource(D3D12_HEAP_FLAGS heapFlags, const D3D12_RE
 	if (!requiresNullClearValue(isBuffer, isRenderTarget, isDepthStencil))
 	{
 		optimalClearValue.Format = desc->Format;
-		optimalClearValue.Color[0] = 1.0f;
 
-		switch (desc->Format)
+		if (isDepthStencil)
 		{
-		case DXGI_FORMAT_D32_FLOAT:
-			break;
-		case DXGI_FORMAT_R8G8B8A8_UNORM:
-			optimalClearValue.Color[1] = 0.980f;
-			optimalClearValue.Color[2] = 0.900f;
-			optimalClearValue.Color[3] = 1.0f;
-			break;
+			optimalClearValue.Format = DXGI_FORMAT_D32_FLOAT;
+			optimalClearValue.DepthStencil.Depth = 1.0f;
+			optimalClearValue.DepthStencil.Stencil = 0;
+		}
+		else
+		{
+			optimalClearValue.Color[0] = 1.0f;
+			switch (desc->Format)
+			{
+			case DXGI_FORMAT_R8G8B8A8_UNORM:
+				optimalClearValue.Color[1] = 0.980f;
+				optimalClearValue.Color[2] = 0.900f;
+				optimalClearValue.Color[3] = 1.0f;
+				break;
+			}
 		}
 
 		clearValue = &optimalClearValue;

--- a/source/engine/core/VertexBuffer.cpp
+++ b/source/engine/core/VertexBuffer.cpp
@@ -2,8 +2,9 @@
 
 #include <string>
 
-VertexBuffer::VertexBuffer(ID3D12Resource* resource, UINT sizeInBytes, UINT numOfVertices, const char* name)
-	: resource(resource), sizeInBytes(sizeInBytes), numOfVertices(numOfVertices)
+VertexBuffer::VertexBuffer(ID3D12Resource* resource, UINT sizeInBytes, UINT numOfVertices, const char* name,
+	DirectX::SimpleMath::Vector3 localMin, DirectX::SimpleMath::Vector3 localMax)
+	: resource(resource), sizeInBytes(sizeInBytes), numOfVertices(numOfVertices), localMin(localMin), localMax(localMax)
 {
 	strcpy_s(this->name, name);
 }

--- a/source/engine/core/VertexBuffer.h
+++ b/source/engine/core/VertexBuffer.h
@@ -2,11 +2,13 @@
 
 #include <Windows.h>
 #include <d3d12.h>
+#include "../../externals/SimpleMath/SimpleMath.h"
 
 class VertexBuffer
 {
 public:
-	VertexBuffer(ID3D12Resource* resource, UINT sizeInBytes, UINT numOfVertices, const char* name);
+	VertexBuffer(ID3D12Resource* resource, UINT sizeInBytes, UINT numOfVertices, const char* name,
+		DirectX::SimpleMath::Vector3 localMin, DirectX::SimpleMath::Vector3 localMax);
 	~VertexBuffer();
 	ID3D12Resource* GetResource()
 	{
@@ -20,9 +22,13 @@ public:
 	{
 		return numOfVertices;
 	}
+	DirectX::SimpleMath::Vector3 GetLocalMin() const { return localMin; }
+	DirectX::SimpleMath::Vector3 GetLocalMax() const { return localMax; }
 private:
 	ID3D12Resource* resource;
 	CHAR name[64];
 	UINT sizeInBytes;
 	UINT numOfVertices;
+	DirectX::SimpleMath::Vector3 localMin;
+	DirectX::SimpleMath::Vector3 localMax;
 };

--- a/source/engine/engine/Components.h
+++ b/source/engine/engine/Components.h
@@ -40,6 +40,8 @@ struct SunlightComponent
 	float color[3] = { 1.0f, 0.98f, 0.92f };
 	float ambientStrength = 0.2f;
 	float diffuseStrength = 1.0f;
+	float shadowBias = 0.001f;
+	float shadowSlopeBias = 0.002f;
 };
 
 

--- a/source/engine/engine/Engine.cpp
+++ b/source/engine/engine/Engine.cpp
@@ -161,7 +161,9 @@ void Engine::LoadAssets(GameObjects gameObjects, Cameras cameras, Sunlights sunl
 			.direction = { -0.4f, -1.0f, -0.3f },
 			.color = { 1.0f, 0.98f, 0.92f },
 			.ambientStrength = 0.2f,
-			.diffuseStrength = 1.0f
+			.diffuseStrength = 1.0f,
+			.shadowBias = 0.001f,
+			.shadowSlopeBias = 0.002f
 			});
 	}
 
@@ -207,7 +209,9 @@ void Engine::LoadAssets(GameObjects gameObjects, Cameras cameras, Sunlights sunl
 			.direction = { sunlightData.direction.x, sunlightData.direction.y, sunlightData.direction.z },
 			.color = { sunlightData.color.x, sunlightData.color.y, sunlightData.color.z },
 			.ambientStrength = sunlightData.ambientStrength,
-			.diffuseStrength = sunlightData.diffuseStrength
+			.diffuseStrength = sunlightData.diffuseStrength,
+			.shadowBias = sunlightData.shadowBias,
+			.shadowSlopeBias = sunlightData.shadowSlopeBias
 			});
 		renderContext.RegisterSunlightEntity(sunlightEntity, sunlightData.name.c_str());
 
@@ -217,7 +221,9 @@ void Engine::LoadAssets(GameObjects gameObjects, Cameras cameras, Sunlights sunl
 				.lightDirection = { sunlightData.direction.x, sunlightData.direction.y, sunlightData.direction.z, 0.0f },
 				.lightColor = { sunlightData.color.x, sunlightData.color.y, sunlightData.color.z, 0.0f },
 				.ambientStrength = sunlightData.ambientStrength,
-				.diffuseStrength = sunlightData.diffuseStrength
+				.diffuseStrength = sunlightData.diffuseStrength,
+				.shadowBias = sunlightData.shadowBias,
+				.shadowSlopeBias = sunlightData.shadowSlopeBias
 				});
 			boundFirstEnabledSunlight = true;
 		}
@@ -229,7 +235,9 @@ void Engine::LoadAssets(GameObjects gameObjects, Cameras cameras, Sunlights sunl
 			.lightDirection = { sunlightData.direction.x, sunlightData.direction.y, sunlightData.direction.z, 0.0f },
 			.lightColor = { sunlightData.color.x, sunlightData.color.y, sunlightData.color.z, 0.0f },
 			.ambientStrength = 0.0f,
-			.diffuseStrength = 0.0f
+			.diffuseStrength = 0.0f,
+			.shadowBias = sunlightData.shadowBias,
+			.shadowSlopeBias = sunlightData.shadowSlopeBias
 			});
 	}
 
@@ -420,6 +428,8 @@ void Engine::ProcessSunlights(tinyxml2::XMLElement* scene, Sunlights& sunlights)
 		{
 			sunlightData.ambientStrength = lighting->FloatAttribute("ambient", sunlightData.ambientStrength);
 			sunlightData.diffuseStrength = lighting->FloatAttribute("diffuse", sunlightData.diffuseStrength);
+			sunlightData.shadowBias = lighting->FloatAttribute("shadowBias", sunlightData.shadowBias);
+			sunlightData.shadowSlopeBias = lighting->FloatAttribute("shadowSlopeBias", sunlightData.shadowSlopeBias);
 		}
 
 		sunlights.emplace_back(sunlightData);

--- a/source/engine/engine/Engine.h
+++ b/source/engine/engine/Engine.h
@@ -44,6 +44,8 @@ struct SunlightData
 	DirectX::SimpleMath::Vector3 color = { 1.0f, 0.98f, 0.92f };
 	float ambientStrength = 0.2f;
 	float diffuseStrength = 1.0f;
+	float shadowBias = 0.001f;
+	float shadowSlopeBias = 0.002f;
 };
 
 using Sunlights = std::vector<SunlightData>;

--- a/source/engine/renderer/RenderContext.cpp
+++ b/source/engine/renderer/RenderContext.cpp
@@ -607,7 +607,8 @@ HTexture RenderContext::CreateDepthTexture(UINT width, UINT height, const CHAR* 
 	size_t numOfCharsConverted;;
 	mbstowcs_s(&numOfCharsConverted, wName, tempName, 32);
 	resource->SetName(wName);
-	textures.push_back(new Texture(width, height, resource, &tempName[0], static_cast<size_t>(descHandleOffset)));
+	textures.push_back(new Texture(width, height, resource, &tempName[0],
+		static_cast<size_t>(descHandleOffset), initResourceState));
 
 	return HTexture(textures.size() - 1);
 }

--- a/source/engine/renderer/RenderContext.cpp
+++ b/source/engine/renderer/RenderContext.cpp
@@ -297,7 +297,14 @@ HDepthBuffer RenderContext::CreateDepthBuffer(UINT width, UINT height, const cha
 	CHAR textureName[32];
 	snprintf(textureName, sizeof(textureName), "%s_Texture", name);
 	HTexture depth = CreateDepthTexture(width, height, textureName);
-	deviceContext.GetDevice()->CreateDepthStencilView(textures[depth.Index()]->GetResource(), nullptr, dsvHeap.Allocate(DescriptorHeap::HeapPartition::STATIC));
+	D3D12_DEPTH_STENCIL_VIEW_DESC dsvDesc = {};
+	dsvDesc.Format = DXGI_FORMAT_D32_FLOAT;
+	dsvDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+	dsvDesc.Texture2D.MipSlice = 0;
+	deviceContext.GetDevice()->CreateDepthStencilView(
+		textures[depth.Index()]->GetResource(),
+		&dsvDesc,
+		dsvHeap.Allocate(DescriptorHeap::HeapPartition::STATIC));
 
 	depthBuffers.push_back(new DepthBuffer(width, height, depth.Index(), dsvHeap.Size(DescriptorHeap::HeapPartition::STATIC) - 1, name));
 
@@ -590,7 +597,7 @@ HTexture RenderContext::CreateDepthTexture(UINT width, UINT height, const CHAR* 
 	OutputDebugString(L"CreateDepthTexture\n");
 	D3D12_HEAP_FLAGS heapFlags = D3D12_HEAP_FLAG_NONE;
 
-	CD3DX12_RESOURCE_DESC desc = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_D32_FLOAT,
+	CD3DX12_RESOURCE_DESC desc = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R32_TYPELESS,
 		width, height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL);
 
 	D3D12_RESOURCE_STATES initResourceState = D3D12_RESOURCE_STATE_DEPTH_WRITE;
@@ -1108,6 +1115,14 @@ void RenderContext::BindTexture(HCommandList commandList, HTexture texture, UINT
 		materials[texture.Index()]->GetHandleOffset(), cbvSrvUavHeap.GetDescriptorSize());
 
 	commandLists[commandList.Index()]->GetCommandList()->SetGraphicsRootDescriptorTable(slot + 1, samplerHeap.GetHeap()->GetGPUDescriptorHandleForHeapStart());
+	commandLists[commandList.Index()]->GetCommandList()->SetGraphicsRootDescriptorTable(slot, textureHandle);
+}
+
+void RenderContext::BindTextureSRV(HCommandList commandList, HTexture texture, UINT slot)
+{
+	CD3DX12_GPU_DESCRIPTOR_HANDLE textureHandle(cbvSrvUavHeap.GetHeap()->GetGPUDescriptorHandleForHeapStart(),
+		textures[texture.Index()]->GetSrvDescriptorIndex(), cbvSrvUavHeap.GetDescriptorSize());
+
 	commandLists[commandList.Index()]->GetCommandList()->SetGraphicsRootDescriptorTable(slot, textureHandle);
 }
 

--- a/source/engine/renderer/RenderContext.cpp
+++ b/source/engine/renderer/RenderContext.cpp
@@ -395,6 +395,25 @@ HPipelineState RenderContext::CreatePipelineState(DeviceContext* deviceContext, 
 	return HPipelineState(pipelineStates.size() - 1);
 }
 
+HPipelineState RenderContext::CreateDepthOnlyPipelineState(DeviceContext* deviceContext, HRootSignature rootSignature,
+	HShader vertexShader, HInputLayout inputLayout)
+{
+	OutputDebugString(L"CreateDepthOnlyPipelineState\n");
+
+	assert(inputLayout.IsValid() && "InputLayout is not valid");
+	assert(rootSignature.IsValid() && "RootSignature is not valid");
+
+	PipelineState* pipelineState = new PipelineState();
+	pipelineState->CreateDepthOnly(inputLayouts[inputLayout.Index()]->GetInputLayoutDesc(),
+		rootSignatures[rootSignature.Index()]->GetRootSignature(),
+		CD3DX12_SHADER_BYTECODE(shaders[vertexShader.Index()]->GetBlob()));
+
+	pipelineStates.push_back(pipelineState);
+
+	OutputDebugString(L"CreateDepthOnlyPipelineState succeeded\n");
+	return HPipelineState(pipelineStates.size() - 1);
+}
+
 HPipelineState RenderContext::CreatePipelineState(DeviceContext* deviceContext, HRootSignature rootSignature, HShader computeShader)
 {
 	OutputDebugString(L"CreateComputePipelineState\n");
@@ -1057,6 +1076,27 @@ void RenderContext::BindRenderTargetWithDepth(HCommandList commandList, HRenderT
 	auto viewport = renderTargets[renderTarget.Index()]->GetViewport();
 	auto scissorRect = renderTargets[renderTarget.Index()]->GetScissorRect();
 	commandLists[commandList.Index()]->GetCommandList()->OMSetRenderTargets(1, &rtvHandle, FALSE, &dsvHandle);
+	commandLists[commandList.Index()]->GetCommandList()->RSSetViewports(1, &viewport);
+	commandLists[commandList.Index()]->GetCommandList()->RSSetScissorRects(1, &scissorRect);
+}
+
+void RenderContext::BindDepthBuffer(HCommandList commandList, HDepthBuffer depthBuffer)
+{
+	auto dsvHandleIndex = depthBuffers[depthBuffer.Index()]->GetDescriptorIndex();
+	auto dsvHandle = dsvHeap.Get(DescriptorHeap::HeapPartition::STATIC, dsvHandleIndex);
+	D3D12_VIEWPORT viewport = {};
+	viewport.TopLeftX = 0.0f;
+	viewport.TopLeftY = 0.0f;
+	viewport.Width = static_cast<float>(depthBuffers[depthBuffer.Index()]->GetWidth());
+	viewport.Height = static_cast<float>(depthBuffers[depthBuffer.Index()]->GetHeight());
+	viewport.MinDepth = 0.0f;
+	viewport.MaxDepth = 1.0f;
+	D3D12_RECT scissorRect = {};
+	scissorRect.left = 0;
+	scissorRect.top = 0;
+	scissorRect.right = static_cast<LONG>(depthBuffers[depthBuffer.Index()]->GetWidth());
+	scissorRect.bottom = static_cast<LONG>(depthBuffers[depthBuffer.Index()]->GetHeight());
+	commandLists[commandList.Index()]->GetCommandList()->OMSetRenderTargets(0, nullptr, FALSE, &dsvHandle);
 	commandLists[commandList.Index()]->GetCommandList()->RSSetViewports(1, &viewport);
 	commandLists[commandList.Index()]->GetCommandList()->RSSetScissorRects(1, &scissorRect);
 }

--- a/source/engine/renderer/RenderContext.cpp
+++ b/source/engine/renderer/RenderContext.cpp
@@ -238,10 +238,19 @@ HDepthBuffer RenderContext::CreateDepthBuffer()
 {
 	OutputDebugString(L"CreateDepthBuffer\n");
 
-	HTexture depth = CreateDepthTexture(windowContext.GetWidth(), windowContext.GetHeight(), "DB_Custom_Texture");
+	return CreateDepthBuffer(windowContext.GetWidth(), windowContext.GetHeight(), "DB_Custom");
+}
+
+HDepthBuffer RenderContext::CreateDepthBuffer(UINT width, UINT height, const char* name)
+{
+	OutputDebugString(L"CreateDepthBuffer\n");
+
+	CHAR textureName[32];
+	snprintf(textureName, sizeof(textureName), "%s_Texture", name);
+	HTexture depth = CreateDepthTexture(width, height, textureName);
 	deviceContext.GetDevice()->CreateDepthStencilView(textures[depth.Index()]->GetResource(), nullptr, dsvHeap.Allocate(DescriptorHeap::HeapPartition::STATIC));
 
-	depthBuffers.push_back(new DepthBuffer(windowContext.GetWidth(), windowContext.GetHeight(), depth.Index(), dsvHeap.Size(DescriptorHeap::HeapPartition::STATIC) - 1, "DB_Custom"));
+	depthBuffers.push_back(new DepthBuffer(width, height, depth.Index(), dsvHeap.Size(DescriptorHeap::HeapPartition::STATIC) - 1, name));
 
 	return HDepthBuffer(depthBuffers.size() - 1);
 }
@@ -944,6 +953,11 @@ void RenderContext::LoadTextureFromFile(UINT width, UINT height, HBuffer& buffer
 HTexture RenderContext::GetTexture(HRenderTarget renderTarget)
 {
 	return HTexture(renderTargets[renderTarget.Index()]->GetTextureIndex());
+}
+
+HTexture RenderContext::GetTexture(HDepthBuffer depthBuffer)
+{
+	return HTexture(depthBuffers[depthBuffer.Index()]->GetTextureIndex());
 }
 
 HTexture RenderContext::GetTexture(const char* name)

--- a/source/engine/renderer/RenderContext.cpp
+++ b/source/engine/renderer/RenderContext.cpp
@@ -21,6 +21,8 @@
 #include "debugapi.h"
 #include "../Utils.h"
 
+#include <algorithm>
+#include <cmath>
 #include <cstring>
 
 extern WindowContext windowContext;
@@ -179,6 +181,53 @@ void RenderContext::RegisterSunlightEntity(uint32_t id, const char* name)
 	record.kind = SceneEntityKind::Sunlight;
 	strncpy_s(record.name, name, _TRUNCATE);
 	sceneEntities.push_back(record);
+}
+
+void RenderContext::UpdateSunlightViewProjection()
+{
+	using DirectX::SimpleMath::Matrix;
+	using DirectX::SimpleMath::Vector3;
+
+	Vector3 sceneCenter = Vector3::Zero;
+	for (const RenderItem& item : renderItems)
+	{
+		sceneCenter += item.position;
+	}
+
+	if (!renderItems.empty())
+	{
+		sceneCenter /= static_cast<float>(renderItems.size());
+	}
+
+	float sceneRadius = 20.0f;
+	for (const RenderItem& item : renderItems)
+	{
+		const float itemDistance = (item.position - sceneCenter).Length();
+		const float itemScale = (std::max)(item.scale.x, (std::max)(item.scale.y, item.scale.z));
+		sceneRadius = (std::max)(sceneRadius, itemDistance + itemScale);
+	}
+
+	Vector3 lightDirection(
+		sunlightConstants.lightDirection[0],
+		sunlightConstants.lightDirection[1],
+		sunlightConstants.lightDirection[2]);
+	if (lightDirection.LengthSquared() < 0.0001f)
+	{
+		lightDirection = Vector3(-0.4f, -1.0f, -0.3f);
+	}
+	lightDirection.Normalize();
+
+	Vector3 up = Vector3::UnitY;
+	if (fabsf(lightDirection.Dot(up)) > 0.95f)
+	{
+		up = Vector3::UnitZ;
+	}
+
+	const float lightDistance = sceneRadius * 2.0f;
+	const Vector3 lightPosition = sceneCenter - lightDirection * lightDistance;
+	const Matrix lightView = Matrix::CreateLookAt(lightPosition, sceneCenter, up);
+	const Matrix lightProjection = Matrix::CreateOrthographic(sceneRadius * 2.0f, sceneRadius * 2.0f, 0.1f, sceneRadius * 4.0f);
+	sunlightViewProjection.viewProjection = lightView * lightProjection;
 }
 
 void RenderContext::CreateRenderItem(const RenderItem& item)

--- a/source/engine/renderer/RenderContext.cpp
+++ b/source/engine/renderer/RenderContext.cpp
@@ -22,6 +22,7 @@
 #include "../Utils.h"
 
 #include <algorithm>
+#include <cfloat>
 #include <cmath>
 #include <cstring>
 
@@ -188,25 +189,6 @@ void RenderContext::UpdateSunlightViewProjection()
 	using DirectX::SimpleMath::Matrix;
 	using DirectX::SimpleMath::Vector3;
 
-	Vector3 sceneCenter = Vector3::Zero;
-	for (const RenderItem& item : renderItems)
-	{
-		sceneCenter += item.position;
-	}
-
-	if (!renderItems.empty())
-	{
-		sceneCenter /= static_cast<float>(renderItems.size());
-	}
-
-	float sceneRadius = 20.0f;
-	for (const RenderItem& item : renderItems)
-	{
-		const float itemDistance = (item.position - sceneCenter).Length();
-		const float itemScale = (std::max)(item.scale.x, (std::max)(item.scale.y, item.scale.z));
-		sceneRadius = (std::max)(sceneRadius, itemDistance + itemScale);
-	}
-
 	Vector3 lightDirection(
 		sunlightConstants.lightDirection[0],
 		sunlightConstants.lightDirection[1],
@@ -223,10 +205,79 @@ void RenderContext::UpdateSunlightViewProjection()
 		up = Vector3::UnitZ;
 	}
 
+	Vector3 sceneMin(FLT_MAX, FLT_MAX, FLT_MAX);
+	Vector3 sceneMax(-FLT_MAX, -FLT_MAX, -FLT_MAX);
+	for (const RenderItem& item : renderItems)
+	{
+		if (!item.mesh.IsValid())
+		{
+			continue;
+		}
+
+		const Mesh* mesh = meshes[item.mesh.Index()];
+		const Vector3 localMin = mesh->GetLocalMin();
+		const Vector3 localMax = mesh->GetLocalMax();
+		const Matrix world = item.World();
+		for (int x = 0; x < 2; ++x)
+		{
+			for (int y = 0; y < 2; ++y)
+			{
+				for (int z = 0; z < 2; ++z)
+				{
+					const Vector3 localCorner(
+						x == 0 ? localMin.x : localMax.x,
+						y == 0 ? localMin.y : localMax.y,
+						z == 0 ? localMin.z : localMax.z);
+					const Vector3 worldCorner = Vector3::Transform(localCorner, world);
+					sceneMin = Vector3::Min(sceneMin, worldCorner);
+					sceneMax = Vector3::Max(sceneMax, worldCorner);
+				}
+			}
+		}
+	}
+
+	if (sceneMin.x == FLT_MAX)
+	{
+		sceneMin = Vector3(-1.0f, -1.0f, -1.0f);
+		sceneMax = Vector3(1.0f, 1.0f, 1.0f);
+	}
+
+	const Vector3 sceneCenter = (sceneMin + sceneMax) * 0.5f;
+	const Vector3 sceneExtents = (sceneMax - sceneMin) * 0.5f;
+	const float sceneRadius = (std::max)(sceneExtents.Length(), 0.5f);
 	const float lightDistance = sceneRadius * 2.0f;
 	const Vector3 lightPosition = sceneCenter - lightDirection * lightDistance;
 	const Matrix lightView = Matrix::CreateLookAt(lightPosition, sceneCenter, up);
-	const Matrix lightProjection = Matrix::CreateOrthographic(sceneRadius * 2.0f, sceneRadius * 2.0f, 0.1f, sceneRadius * 4.0f);
+
+	Vector3 lightMin(FLT_MAX, FLT_MAX, FLT_MAX);
+	Vector3 lightMax(-FLT_MAX, -FLT_MAX, -FLT_MAX);
+	for (int x = 0; x < 2; ++x)
+	{
+		for (int y = 0; y < 2; ++y)
+		{
+			for (int z = 0; z < 2; ++z)
+			{
+				const Vector3 worldCorner(
+					x == 0 ? sceneMin.x : sceneMax.x,
+					y == 0 ? sceneMin.y : sceneMax.y,
+					z == 0 ? sceneMin.z : sceneMax.z);
+				const Vector3 lightCorner = Vector3::Transform(worldCorner, lightView);
+				lightMin = Vector3::Min(lightMin, lightCorner);
+				lightMax = Vector3::Max(lightMax, lightCorner);
+			}
+		}
+	}
+
+	const float padding = sceneRadius * 0.15f;
+	const float nearPlane = (std::max)(-lightMax.z - padding, 0.1f);
+	const float farPlane = (std::max)(-lightMin.z + padding, nearPlane + 0.5f);
+	const Matrix lightProjection = Matrix::CreateOrthographicOffCenter(
+		lightMin.x - padding,
+		lightMax.x + padding,
+		lightMin.y - padding,
+		lightMax.y + padding,
+		nearPlane,
+		farPlane);
 	sunlightViewProjection.viewProjection = lightView * lightProjection;
 }
 
@@ -446,6 +497,8 @@ HInputLayout RenderContext::CreateInputLayout()
 
 HVertexBuffer RenderContext::CreateVertexBuffer(UINT numOfVertices, UINT numOfFloatsPerVertex, FLOAT* meshData, const CHAR* name)
 {
+	using DirectX::SimpleMath::Vector3;
+
 	OutputDebugString(L"CreateVertexBuffer\n");
 	
 	// Each vertex is: 4xFLOAT for position + 4xFLOAT for color
@@ -468,7 +521,25 @@ HVertexBuffer RenderContext::CreateVertexBuffer(UINT numOfVertices, UINT numOfFl
 	mbstowcs_s(&numOfCharsConverted, wName, tempName, 32);
 	vertexBuffer->SetName(wName);
 
-	vertexBuffers.push_back(new VertexBuffer(vertexBuffer, vbSizeInBytes, numOfVertices, tempName));
+	Vector3 localMin(FLT_MAX, FLT_MAX, FLT_MAX);
+	Vector3 localMax(-FLT_MAX, -FLT_MAX, -FLT_MAX);
+	if (meshData != nullptr && numOfFloatsPerVertex >= 3)
+	{
+		for (UINT vertexIndex = 0; vertexIndex < numOfVertices; ++vertexIndex)
+		{
+			const UINT offset = vertexIndex * numOfFloatsPerVertex;
+			const Vector3 position(meshData[offset + 0], meshData[offset + 1], meshData[offset + 2]);
+			localMin = Vector3::Min(localMin, position);
+			localMax = Vector3::Max(localMax, position);
+		}
+	}
+	else
+	{
+		localMin = Vector3(-1.0f, -1.0f, -1.0f);
+		localMax = Vector3(1.0f, 1.0f, 1.0f);
+	}
+
+	vertexBuffers.push_back(new VertexBuffer(vertexBuffer, vbSizeInBytes, numOfVertices, tempName, localMin, localMax));
 	
 	// Copy the triangle data to the vertex buffer.
 	UINT8* pVertexDataBegin;
@@ -820,8 +891,10 @@ void RenderContext::CreateMesh(HVertexBuffer vbIndexPosition, HVertexBuffer vbIn
 	D3D12_VERTEX_BUFFER_VIEW vbvNormalsTexture = createVBV(vbNormalsTexture, 4 * sizeof(float));
 
 	UINT vertexCount = vertexBuffers[vbIndexPosition.Index()]->GetNumOfVertices();
+	const auto localMin = vertexBuffers[vbIndexPosition.Index()]->GetLocalMin();
+	const auto localMax = vertexBuffers[vbIndexPosition.Index()]->GetLocalMax();
 	meshes.push_back(new Mesh(vbIndexPosition.Index(), vbvPosition, vbIndexColor.Index(), vbvColor,
-		vbIndexTexture.Index(), vbvTexture, vbNormalsTexture.Index(), vbvNormalsTexture, vertexCount, name));
+		vbIndexTexture.Index(), vbvTexture, vbNormalsTexture.Index(), vbvNormalsTexture, vertexCount, localMin, localMax, name));
 }
 
 void RenderContext::CreateTexture(UINT width, UINT height, BYTE* data, const CHAR* name)

--- a/source/engine/renderer/RenderContext.h
+++ b/source/engine/renderer/RenderContext.h
@@ -51,6 +51,8 @@ struct SunlightConstants
 	float lightColor[4] = { 1.0f, 0.98f, 0.92f, 0.0f };
 	float ambientStrength = 0.2f;
 	float diffuseStrength = 1.0f;
+	float shadowBias = 0.001f;
+	float shadowSlopeBias = 0.002f;
 };
 
 struct SunlightViewProjection

--- a/source/engine/renderer/RenderContext.h
+++ b/source/engine/renderer/RenderContext.h
@@ -53,6 +53,11 @@ struct SunlightConstants
 	float diffuseStrength = 1.0f;
 };
 
+struct SunlightViewProjection
+{
+	DirectX::SimpleMath::Matrix viewProjection = DirectX::SimpleMath::Matrix::Identity;
+};
+
 class RenderContext
 {
 public:
@@ -87,6 +92,8 @@ public:
 	void RegisterSunlightEntity(uint32_t id, const char* name);
 	const SunlightConstants& GetSunlightConstants() const { return sunlightConstants; }
 	void SetSunlightConstants(const SunlightConstants& constants) { sunlightConstants = constants; }
+	void UpdateSunlightViewProjection();
+	const SunlightViewProjection& GetSunlightViewProjection() const { return sunlightViewProjection; }
 	void CreateRenderItem(const RenderItem& item);
 	HRenderTarget CreateRenderTarget(const char* name, RenderTargetFormat format);
 	HRenderTarget CreateRenderTarget(const char* name, RenderTargetFormat format, int width, int height);
@@ -198,6 +205,7 @@ private:
 	std::vector<Camera*> cameras;
 	std::vector<SceneEntityRecord> sceneEntities;
 	SunlightConstants sunlightConstants;
+	SunlightViewProjection sunlightViewProjection;
 private:
 	uint32_t currentSelectedObjectID = ~0u; // ~0u == invalid ID (aka nothing selected)
 	bool wasObjectSeleced = false;

--- a/source/engine/renderer/RenderContext.h
+++ b/source/engine/renderer/RenderContext.h
@@ -69,6 +69,8 @@ public:
 	HShader CreateShader(LPCWSTR shaderFileName, LPCSTR entryPoint, LPCSTR shaderModel);
 	HPipelineState CreatePipelineState(DeviceContext* deviceContext, HRootSignature rootSignature, HShader vertexShader,
 		HShader pixelShader, HInputLayout inputLayout, HRenderTarget renderTarget);
+	HPipelineState CreateDepthOnlyPipelineState(DeviceContext* deviceContext, HRootSignature rootSignature,
+		HShader vertexShader, HInputLayout inputLayout);
 	HPipelineState CreatePipelineState(DeviceContext* deviceContext, HRootSignature rootSignature, HShader computeShader);
 	HInputLayout CreateInputLayout();
 	InputLayout* GetInputLayout(HInputLayout inputLayout) { return inputLayouts[inputLayout.Index()]; }
@@ -157,6 +159,7 @@ public:
 	// Binding
 	void BindRenderTarget(HCommandList commandList, HRenderTarget renderTarget);
 	void BindRenderTargetWithDepth(HCommandList commandList, HRenderTarget renderTarget, HDepthBuffer depthBuffer);
+	void BindDepthBuffer(HCommandList commandList, HDepthBuffer depthBuffer);
 	void ResetCommandList(HCommandList commandList, HPipelineState pipelineState);
 	void ResetCommandList(HCommandList commandList);
 	void CloseCommandList(HCommandList commandList);

--- a/source/engine/renderer/RenderContext.h
+++ b/source/engine/renderer/RenderContext.h
@@ -96,6 +96,8 @@ public:
 	void SetSunlightConstants(const SunlightConstants& constants) { sunlightConstants = constants; }
 	void UpdateSunlightViewProjection();
 	const SunlightViewProjection& GetSunlightViewProjection() const { return sunlightViewProjection; }
+	void SetShadowMapTexture(HTexture texture) { shadowMapTexture = texture; }
+	HTexture GetShadowMapTexture() const { return shadowMapTexture; }
 	void CreateRenderItem(const RenderItem& item);
 	HRenderTarget CreateRenderTarget(const char* name, RenderTargetFormat format);
 	HRenderTarget CreateRenderTarget(const char* name, RenderTargetFormat format, int width, int height);
@@ -170,6 +172,7 @@ public:
 	void BindConstantBuffer(HCommandList commandList, HBuffer buffer, UINT slot);
 	void UpdateConstantBuffer(HBuffer buffer, const void* data, UINT sizeInBytes);
 	void BindTexture(HCommandList commandList, HTexture texture, UINT slot);
+	void BindTextureSRV(HCommandList commandList, HTexture texture, UINT slot);
 	void BindTextureOnlyUAV(HCommandList commandList, HTexture texture, UINT slot);
 	void BindTextureOnlySRV(HCommandList commandList, HTexture texture, UINT slot);
 	// Clearing
@@ -209,6 +212,7 @@ private:
 	std::vector<SceneEntityRecord> sceneEntities;
 	SunlightConstants sunlightConstants;
 	SunlightViewProjection sunlightViewProjection;
+	HTexture shadowMapTexture;
 private:
 	uint32_t currentSelectedObjectID = ~0u; // ~0u == invalid ID (aka nothing selected)
 	bool wasObjectSeleced = false;

--- a/source/engine/renderer/RenderContext.h
+++ b/source/engine/renderer/RenderContext.h
@@ -92,6 +92,7 @@ public:
 	HRenderTarget CreateRenderTarget(const char* name, RenderTargetFormat format, int width, int height);
 	HRenderTarget CreateRenderTarget(const char* name, HTexture texture);
 	HDepthBuffer CreateDepthBuffer();
+	HDepthBuffer CreateDepthBuffer(UINT width, UINT height, const char* name);
 	void CreateMesh(HVertexBuffer vbIndexPosition, HVertexBuffer vbIndexColor, HVertexBuffer vbIndexTexture, HVertexBuffer vbNormalsTexture, const CHAR* name);
 	void CreateTexture(UINT width, UINT height, BYTE* data, const CHAR* name);
 	UINT CreateUnorderedAccessView(ID3D12Resource* resource, DXGI_FORMAT format, bool isStatic);
@@ -101,6 +102,7 @@ public:
 	UINT GetActiveCameraIndex() const { return activeCameraIndex; }
 	void SetActiveCamera(UINT index) { activeCameraIndex = index; }
 	HTexture GetTexture(HRenderTarget renderTarget);
+	HTexture GetTexture(HDepthBuffer depthBuffer);
 	HTexture GetTexture(const char* name);
 	std::vector<uint8_t> ReadbackBufferData(HBuffer handle, size_t size);
 	void SetSelectedObjectId(uint32_t id) { currentSelectedObjectID = id; }

--- a/source/engine/renderer/RenderGraph.cpp
+++ b/source/engine/renderer/RenderGraph.cpp
@@ -9,11 +9,15 @@
 #include "passes/HighlightPass.h"
 #include "passes/GrayscalePass.h"
 #include "passes/CompositionPass.h"
+#include "passes/ShadowMapPass.h"
 
 RenderGraph::RenderGraph()
 {
 	RenderPass* selectionPass = new SelectionPass();
 	renderPasses.push_back(selectionPass);
+
+	RenderPass* shadowMapPass = new ShadowMapPass();
+	renderPasses.push_back(shadowMapPass);
 
 	RenderPass* forwardPass = new ForwardPass();
 	renderPasses.push_back(forwardPass);

--- a/source/engine/renderer/passes/ForwardPass.cpp
+++ b/source/engine/renderer/passes/ForwardPass.cpp
@@ -58,6 +58,8 @@ void ForwardPass::ConfigurePipelineState()
 	builder.AddCBV(2, D3D12_SHADER_VISIBILITY_PIXEL); // CBV t2 (light data)
 	builder.AddSRVTable(0, 1, D3D12_SHADER_VISIBILITY_PIXEL); // SRV t0
 	builder.AddSamplerTable(0, 1, D3D12_SHADER_VISIBILITY_PIXEL); // Sampler s0
+	builder.AddSRVTable(1, 1, D3D12_SHADER_VISIBILITY_PIXEL); // SRV t1 (shadow map)
+	builder.AddCBV(3, D3D12_SHADER_VISIBILITY_VERTEX); // CBV b3 (light view-projection)
 	rootSignature = renderContext.CreateRootSignature(builder);
 
 	// Menu height seems to be 20 pixels
@@ -74,6 +76,9 @@ void ForwardPass::ConfigurePipelineState()
 	sunlightBuffer = renderContext.CreateConsantBuffer<SunlightConstants>();
 	const SunlightConstants& sunlightConstants = renderContext.GetSunlightConstants();
 	renderContext.UpdateConstantBuffer(sunlightBuffer, &sunlightConstants, sizeof(sunlightConstants));
+	sunlightViewProjectionBuffer = renderContext.CreateConsantBuffer<SunlightViewProjection>();
+	const SunlightViewProjection& sunlightViewProjection = renderContext.GetSunlightViewProjection();
+	renderContext.UpdateConstantBuffer(sunlightViewProjectionBuffer, &sunlightViewProjection, sizeof(sunlightViewProjection));
 	deviceContext.Flush();
 }
 
@@ -144,6 +149,14 @@ void ForwardPass::Execute()
 	const SunlightConstants& sunlightConstants = renderContext.GetSunlightConstants();
 	renderContext.UpdateConstantBuffer(sunlightBuffer, &sunlightConstants, sizeof(sunlightConstants));
 	renderContext.BindConstantBuffer(commandList, sunlightBuffer, 2);
+	const SunlightViewProjection& sunlightViewProjection = renderContext.GetSunlightViewProjection();
+	renderContext.UpdateConstantBuffer(sunlightViewProjectionBuffer, &sunlightViewProjection, sizeof(sunlightViewProjection));
+	renderContext.BindConstantBuffer(commandList, sunlightViewProjectionBuffer, 6);
+	HTexture shadowMapTexture = renderContext.GetShadowMapTexture();
+	if (shadowMapTexture.IsValid())
+	{
+		renderContext.BindTextureSRV(commandList, shadowMapTexture, 5);
+	}
 
 	const auto& items = renderContext.GetRenderItems();
 	for (const RenderItem& item : items)

--- a/source/engine/renderer/passes/ForwardPass.h
+++ b/source/engine/renderer/passes/ForwardPass.h
@@ -25,4 +25,5 @@ private:
 	FreeCamera* freeCamera;
 	BOOL isPerspectiveCamera = TRUE;
 	HBuffer sunlightBuffer;
+	HBuffer sunlightViewProjectionBuffer;
 };

--- a/source/engine/renderer/passes/ImGuiPass.cpp
+++ b/source/engine/renderer/passes/ImGuiPass.cpp
@@ -46,7 +46,9 @@ namespace
 			.lightDirection = { sunlight.direction[0], sunlight.direction[1], sunlight.direction[2], 0.0f },
 			.lightColor = { sunlight.color[0], sunlight.color[1], sunlight.color[2], 0.0f },
 			.ambientStrength = sunlight.ambientStrength * enabled,
-			.diffuseStrength = sunlight.diffuseStrength * enabled
+			.diffuseStrength = sunlight.diffuseStrength * enabled,
+			.shadowBias = sunlight.shadowBias,
+			.shadowSlopeBias = sunlight.shadowSlopeBias
 		};
 	}
 
@@ -337,6 +339,8 @@ void ImGuiPass::Execute()
 							changed |= ImGui::ColorEdit3("Color", sunlight.color);
 							changed |= ImGui::DragFloat("Ambient", &sunlight.ambientStrength, 0.01f, 0.0f, 1.0f);
 							changed |= ImGui::DragFloat("Diffuse", &sunlight.diffuseStrength, 0.01f, 0.0f, 10.0f);
+							changed |= ImGui::DragFloat("Shadow Bias", &sunlight.shadowBias, 0.0001f, 0.0f, 0.05f, "%.6f");
+							changed |= ImGui::DragFloat("Shadow Slope Bias", &sunlight.shadowSlopeBias, 0.0001f, 0.0f, 0.05f, "%.6f");
 
 							if (changed)
 							{

--- a/source/engine/renderer/passes/ShadowMapPass.cpp
+++ b/source/engine/renderer/passes/ShadowMapPass.cpp
@@ -1,9 +1,11 @@
 #include "ShadowMapPass.h"
 #include "../RenderContext.h"
 #include "../../bind/RootSignatureBuilder.h"
+#include "../../core/DeviceContext.h"
 #include "../../core/InputLayout.h"
 
 extern RenderContext renderContext;
+extern DeviceContext deviceContext;
 
 ShadowMapPass::ShadowMapPass() : RenderPass(L"ShadowMap", L"shadow_map.hlsl", Type::Graphics)
 {
@@ -42,6 +44,7 @@ void ShadowMapPass::PostAssetLoad()
 
 void ShadowMapPass::Initialize()
 {
+	pipelineState = renderContext.CreateDepthOnlyPipelineState(&deviceContext, rootSignature, vertexShader, inputLayout);
 }
 
 void ShadowMapPass::Update()
@@ -50,9 +53,9 @@ void ShadowMapPass::Update()
 
 void ShadowMapPass::Execute()
 {
-    renderContext.SetupRenderPass(commandList, pipelineState, rootSignature);
-    renderContext.BindRenderTargetWithDepth(commandList, renderTarget, depthBuffer);
-    renderContext.ClearDepthBuffer(commandList, depthBuffer);
+	renderContext.SetupRenderPass(commandList, pipelineState, rootSignature);
+	renderContext.BindDepthBuffer(commandList, depthBuffer);
+	renderContext.ClearDepthBuffer(commandList, depthBuffer);
 
     renderContext.UpdateSunlightViewProjection();
     const SunlightViewProjection& lightViewProjection = renderContext.GetSunlightViewProjection();

--- a/source/engine/renderer/passes/ShadowMapPass.cpp
+++ b/source/engine/renderer/passes/ShadowMapPass.cpp
@@ -23,7 +23,11 @@ void ShadowMapPass::ConfigurePipelineState()
     RootSignatureBuilder builder;
     rootSignature = renderContext.CreateRootSignature(builder);
 
-    renderTarget = renderContext.CreateRenderTarget("RT_ShadowMapPass", RenderTargetFormat::RGB8_UNORM, 64, 64);
+    depthBuffer = renderContext.CreateDepthBuffer(ShadowMapSize, ShadowMapSize, "DB_ShadowMap");
+    shadowMapTexture = renderContext.GetTexture(depthBuffer);
+
+    // Temporary color target until the shadow pass gets a depth-only PSO.
+    renderTarget = renderContext.CreateRenderTarget("RT_ShadowMapPass", RenderTargetFormat::RGB8_UNORM, ShadowMapSize, ShadowMapSize);
 }
 
 void ShadowMapPass::PostAssetLoad()

--- a/source/engine/renderer/passes/ShadowMapPass.cpp
+++ b/source/engine/renderer/passes/ShadowMapPass.cpp
@@ -29,6 +29,7 @@ void ShadowMapPass::ConfigurePipelineState()
 
     depthBuffer = renderContext.CreateDepthBuffer(ShadowMapSize, ShadowMapSize, "DB_ShadowMap");
     shadowMapTexture = renderContext.GetTexture(depthBuffer);
+    renderContext.SetShadowMapTexture(shadowMapTexture);
     lightViewProjectionBuffer = renderContext.CreateConsantBuffer<SunlightViewProjection>();
     renderContext.UpdateSunlightViewProjection();
     const SunlightViewProjection& lightViewProjection = renderContext.GetSunlightViewProjection();
@@ -75,6 +76,8 @@ void ShadowMapPass::Execute()
 		renderContext.BindGeometry(commandList, item.mesh);
 		renderContext.DrawMesh(commandList, item.mesh);
 	}
+
+	renderContext.TransitionTo(commandList, shadowMapTexture, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
 }
 
 void ShadowMapPass::PostSubmit()

--- a/source/engine/renderer/passes/ShadowMapPass.cpp
+++ b/source/engine/renderer/passes/ShadowMapPass.cpp
@@ -21,6 +21,8 @@ void ShadowMapPass::ConfigurePipelineState()
 
     // Now we can create the root signature
     RootSignatureBuilder builder;
+    builder.AddCBV(0, D3D12_SHADER_VISIBILITY_VERTEX); // Light view-projection @ b0
+    builder.AddConstants(16, 1, 0, D3D12_SHADER_VISIBILITY_VERTEX); // Object world @ b1
     rootSignature = renderContext.CreateRootSignature(builder);
 
     depthBuffer = renderContext.CreateDepthBuffer(ShadowMapSize, ShadowMapSize, "DB_ShadowMap");
@@ -48,9 +50,14 @@ void ShadowMapPass::Update()
 
 void ShadowMapPass::Execute()
 {
+    renderContext.SetupRenderPass(commandList, pipelineState, rootSignature);
+    renderContext.BindRenderTargetWithDepth(commandList, renderTarget, depthBuffer);
+    renderContext.ClearDepthBuffer(commandList, depthBuffer);
+
     renderContext.UpdateSunlightViewProjection();
     const SunlightViewProjection& lightViewProjection = renderContext.GetSunlightViewProjection();
     renderContext.UpdateConstantBuffer(lightViewProjectionBuffer, &lightViewProjection, sizeof(lightViewProjection));
+    renderContext.BindConstantBuffer(commandList, lightViewProjectionBuffer, 0);
 }
 
 void ShadowMapPass::PostSubmit()

--- a/source/engine/renderer/passes/ShadowMapPass.cpp
+++ b/source/engine/renderer/passes/ShadowMapPass.cpp
@@ -25,6 +25,10 @@ void ShadowMapPass::ConfigurePipelineState()
 
     depthBuffer = renderContext.CreateDepthBuffer(ShadowMapSize, ShadowMapSize, "DB_ShadowMap");
     shadowMapTexture = renderContext.GetTexture(depthBuffer);
+    lightViewProjectionBuffer = renderContext.CreateConsantBuffer<SunlightViewProjection>();
+    renderContext.UpdateSunlightViewProjection();
+    const SunlightViewProjection& lightViewProjection = renderContext.GetSunlightViewProjection();
+    renderContext.UpdateConstantBuffer(lightViewProjectionBuffer, &lightViewProjection, sizeof(lightViewProjection));
 
     // Temporary color target until the shadow pass gets a depth-only PSO.
     renderTarget = renderContext.CreateRenderTarget("RT_ShadowMapPass", RenderTargetFormat::RGB8_UNORM, ShadowMapSize, ShadowMapSize);
@@ -44,6 +48,9 @@ void ShadowMapPass::Update()
 
 void ShadowMapPass::Execute()
 {
+    renderContext.UpdateSunlightViewProjection();
+    const SunlightViewProjection& lightViewProjection = renderContext.GetSunlightViewProjection();
+    renderContext.UpdateConstantBuffer(lightViewProjectionBuffer, &lightViewProjection, sizeof(lightViewProjection));
 }
 
 void ShadowMapPass::PostSubmit()

--- a/source/engine/renderer/passes/ShadowMapPass.cpp
+++ b/source/engine/renderer/passes/ShadowMapPass.cpp
@@ -1,0 +1,51 @@
+#include "ShadowMapPass.h"
+#include "../RenderContext.h"
+#include "../../bind/RootSignatureBuilder.h"
+#include "../../core/InputLayout.h"
+
+extern RenderContext renderContext;
+
+ShadowMapPass::ShadowMapPass() : RenderPass(L"ShadowMap", L"shadow_map.hlsl", Type::Graphics)
+{
+}
+
+ShadowMapPass::~ShadowMapPass()
+{
+}
+
+void ShadowMapPass::ConfigurePipelineState()
+{
+    // Pre-AutomaticInitialize Procedure
+    inputLayout = renderContext.CreateInputLayout();
+    renderContext.GetInputLayout(inputLayout)->AppendElementT(VertexStream::Position);
+
+    // Now we can create the root signature
+    RootSignatureBuilder builder;
+    rootSignature = renderContext.CreateRootSignature(builder);
+
+    renderTarget = renderContext.CreateRenderTarget("RT_ShadowMapPass", RenderTargetFormat::RGB8_UNORM, 64, 64);
+}
+
+void ShadowMapPass::PostAssetLoad()
+{
+}
+
+void ShadowMapPass::Initialize()
+{
+}
+
+void ShadowMapPass::Update()
+{
+}
+
+void ShadowMapPass::Execute()
+{
+}
+
+void ShadowMapPass::PostSubmit()
+{
+}
+
+void ShadowMapPass::Allocate(DeviceContext* deviceContext)
+{
+}

--- a/source/engine/renderer/passes/ShadowMapPass.cpp
+++ b/source/engine/renderer/passes/ShadowMapPass.cpp
@@ -54,6 +54,7 @@ void ShadowMapPass::Update()
 void ShadowMapPass::Execute()
 {
 	renderContext.SetupRenderPass(commandList, pipelineState, rootSignature);
+	renderContext.TransitionTo(commandList, shadowMapTexture, D3D12_RESOURCE_STATE_DEPTH_WRITE);
 	renderContext.BindDepthBuffer(commandList, depthBuffer);
 	renderContext.ClearDepthBuffer(commandList, depthBuffer);
 
@@ -61,6 +62,19 @@ void ShadowMapPass::Execute()
     const SunlightViewProjection& lightViewProjection = renderContext.GetSunlightViewProjection();
     renderContext.UpdateConstantBuffer(lightViewProjectionBuffer, &lightViewProjection, sizeof(lightViewProjection));
     renderContext.BindConstantBuffer(commandList, lightViewProjectionBuffer, 0);
+
+	const auto& items = renderContext.GetRenderItems();
+	for (const RenderItem& item : items)
+	{
+		if (!item.mesh.IsValid())
+		{
+			continue;
+		}
+
+		renderContext.SetInlineConstants(commandList, item.World(), 1);
+		renderContext.BindGeometry(commandList, item.mesh);
+		renderContext.DrawMesh(commandList, item.mesh);
+	}
 }
 
 void ShadowMapPass::PostSubmit()

--- a/source/engine/renderer/passes/ShadowMapPass.h
+++ b/source/engine/renderer/passes/ShadowMapPass.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "../RenderPass.h"
+
+// Type: Graphics
+// Responsible for generating the Shadow Map for the scene
+
+class Orbit;
+
+class ShadowMapPass : public RenderPass
+{
+public:
+    ShadowMapPass();
+    ~ShadowMapPass();
+
+    void ConfigurePipelineState() override;
+    void PostAssetLoad() override;
+    void Initialize() override;
+    void Update() override;
+    void Execute() override;
+    void PostSubmit() override;
+    void Allocate(DeviceContext* deviceContext) override;
+};

--- a/source/engine/renderer/passes/ShadowMapPass.h
+++ b/source/engine/renderer/passes/ShadowMapPass.h
@@ -20,4 +20,7 @@ public:
     void Execute() override;
     void PostSubmit() override;
     void Allocate(DeviceContext* deviceContext) override;
+private:
+    static constexpr UINT ShadowMapSize = 2048;
+    HTexture shadowMapTexture;
 };

--- a/source/engine/renderer/passes/ShadowMapPass.h
+++ b/source/engine/renderer/passes/ShadowMapPass.h
@@ -23,4 +23,5 @@ public:
 private:
     static constexpr UINT ShadowMapSize = 2048;
     HTexture shadowMapTexture;
+    HBuffer lightViewProjectionBuffer;
 };

--- a/source/engine/renderer/shaders/shaders.hlsl
+++ b/source/engine/renderer/shaders/shaders.hlsl
@@ -1,5 +1,6 @@
 SamplerState LinearSampler : register(s0);
 Texture2D myTexture : register(t0);
+Texture2D shadowMap : register(t1);
 
 cbuffer CameraData : register(b0)
 {
@@ -19,6 +20,11 @@ cbuffer SunlightData : register(b2)
     float diffuseStrength;
 };
 
+cbuffer LightViewProjectionData : register(b3)
+{
+    row_major float4x4 lightViewProjection;
+};
+
 struct VSInput
 {
     float4 position : POSITION;
@@ -33,6 +39,8 @@ struct PSInput
     float4 color : COLOR;
     float2 texCoord : TEXCOORD;
     float3 worldNormal : TEXCOORD1;
+    float3 worldPosition : TEXCOORD2;
+    float4 shadowPosition : TEXCOORD3;
 };
 
 PSInput VSMain(VSInput input)
@@ -46,6 +54,8 @@ PSInput VSMain(VSInput input)
     o.color = input.color;
     o.texCoord = input.texCoord;
     o.worldNormal = normalize(mul(input.normal.xyz, (float3x3)world));
+    o.worldPosition = worldPos.xyz;
+    o.shadowPosition = mul(worldPos, lightViewProjection);
     return o;
 }
 
@@ -55,9 +65,20 @@ float4 PSMain(PSInput input) : SV_TARGET
     float4 albedo = myTexture.Sample(LinearSampler, uv);
 
     float3 normal = normalize(input.worldNormal);
+    float3 shadowNdc = input.shadowPosition.xyz / input.shadowPosition.w;
+    float2 shadowUv = shadowNdc.xy * float2(0.5f, -0.5f) + 0.5f;
+    float pixelLightDepth = shadowNdc.z;
+    float shadowMapDepth = shadowMap.Sample(LinearSampler, shadowUv).r;
+    float shadowBias = 0.001f;
+    bool insideShadowMap =
+        shadowUv.x >= 0.0f && shadowUv.x <= 1.0f &&
+        shadowUv.y >= 0.0f && shadowUv.y <= 1.0f &&
+        pixelLightDepth >= 0.0f && pixelLightDepth <= 1.0f;
+    float shadowVisibility = (!insideShadowMap || pixelLightDepth <= shadowMapDepth + shadowBias) ? 1.0f : 0.0f;
 
     float diffuse = saturate(dot(normal, -normalize(lightDirection.xyz))) * diffuseStrength;
-
-    float3 lighting = lightColor.xyz * (ambientStrength + diffuse);
+    float3 ambientLight = lightColor.xyz * ambientStrength;
+    float3 directLight = lightColor.xyz * diffuse * shadowVisibility;
+    float3 lighting = ambientLight + directLight;
     return float4(albedo.rgb * lighting, albedo.a);
 }

--- a/source/engine/renderer/shaders/shaders.hlsl
+++ b/source/engine/renderer/shaders/shaders.hlsl
@@ -18,6 +18,8 @@ cbuffer SunlightData : register(b2)
     float4 lightColor;
     float ambientStrength;
     float diffuseStrength;
+    float shadowBias;
+    float shadowSlopeBias;
 };
 
 cbuffer LightViewProjectionData : register(b3)
@@ -68,15 +70,16 @@ float4 PSMain(PSInput input) : SV_TARGET
     float3 shadowNdc = input.shadowPosition.xyz / input.shadowPosition.w;
     float2 shadowUv = shadowNdc.xy * float2(0.5f, -0.5f) + 0.5f;
     float pixelLightDepth = shadowNdc.z;
+    float lightFacing = saturate(dot(normal, -normalize(lightDirection.xyz)));
+    float depthBias = max(shadowBias, (1.0f - lightFacing) * shadowSlopeBias);
     float shadowMapDepth = shadowMap.Sample(LinearSampler, shadowUv).r;
-    float shadowBias = 0.001f;
     bool insideShadowMap =
         shadowUv.x >= 0.0f && shadowUv.x <= 1.0f &&
         shadowUv.y >= 0.0f && shadowUv.y <= 1.0f &&
         pixelLightDepth >= 0.0f && pixelLightDepth <= 1.0f;
-    float shadowVisibility = (!insideShadowMap || pixelLightDepth <= shadowMapDepth + shadowBias) ? 1.0f : 0.0f;
+    float shadowVisibility = (!insideShadowMap || pixelLightDepth <= shadowMapDepth + depthBias) ? 1.0f : 0.0f;
 
-    float diffuse = saturate(dot(normal, -normalize(lightDirection.xyz))) * diffuseStrength;
+    float diffuse = lightFacing * diffuseStrength;
     float3 ambientLight = lightColor.xyz * ambientStrength;
     float3 directLight = lightColor.xyz * diffuse * shadowVisibility;
     float3 lighting = ambientLight + directLight;

--- a/source/engine/renderer/shaders/shadow_map.hlsl
+++ b/source/engine/renderer/shaders/shadow_map.hlsl
@@ -1,0 +1,16 @@
+struct PSInput
+{
+    float4 position : SV_POSITION;
+};
+
+PSInput VSMain(float4 position : POSITION)
+{
+    PSInput result;
+    result.position = position;
+    return result;
+}
+
+float4 PSMain(PSInput input) : SV_TARGET
+{
+    return float4(1.0f, 0.0f, 1.0f, 1.0f);
+}

--- a/source/engine/renderer/shaders/shadow_map.hlsl
+++ b/source/engine/renderer/shaders/shadow_map.hlsl
@@ -1,3 +1,13 @@
+cbuffer LightData : register(b0)
+{
+    row_major float4x4 lightViewProjection;
+};
+
+cbuffer ObjectData : register(b1)
+{
+    row_major float4x4 world;
+};
+
 struct PSInput
 {
     float4 position : SV_POSITION;
@@ -6,11 +16,12 @@ struct PSInput
 PSInput VSMain(float4 position : POSITION)
 {
     PSInput result;
-    result.position = position;
+    float4 worldPosition = mul(float4(position.xyz, 1.0f), world);
+    result.position = mul(worldPosition, lightViewProjection);
     return result;
 }
 
 float4 PSMain(PSInput input) : SV_TARGET
 {
-    return float4(1.0f, 0.0f, 1.0f, 1.0f);
+    return float4(0.0f, 0.0f, 0.0f, 1.0f);
 }


### PR DESCRIPTION
## Summary

Adds the shadow map rendering path for sunlight shadows, including a dedicated shadow map pass and shader, depth-only pipeline support, typeless depth buffer handling, and shadow sampling in the forward pass.

The branch also tightens sunlight shadow frustum setup with local scene bounds and exposes configurable shadow bias on the sunlight component.

## Impact

This enables the renderer to generate and consume a shadow map during the frame graph, with supporting pipeline, buffer, and shader changes needed for depth-only shadow rendering.

## Validation

Not run in this publish-only pass.