### PR TITLE
[codex] Add editable simple material controls

### DIFF
--- a/source/engine/engine/Components.h
+++ b/source/engine/engine/Components.h
@@ -23,7 +23,8 @@ struct GeometryComponent
 struct MaterialComponent
 {
 	HTexture textureHandle;
-	// later we can add color, reflectivity, etc.
+	float shininess = 32.0f;
+	float specularStrength = 0.65f;
 };
 
 // Material to store generic info about entity, like name

--- a/source/engine/engine/Components.h
+++ b/source/engine/engine/Components.h
@@ -23,6 +23,7 @@ struct GeometryComponent
 struct MaterialComponent
 {
 	HTexture textureHandle;
+	float diffuseStrength = 1.0f;
 	float shininess = 32.0f;
 	float specularStrength = 0.65f;
 };

--- a/source/engine/engine/Engine.cpp
+++ b/source/engine/engine/Engine.cpp
@@ -190,7 +190,6 @@ void Engine::LoadAssets(GameObjects gameObjects, Cameras cameras, Sunlights sunl
 			.height = cameraData.height,
 			.active = cameraData.active
 			});
-		renderContext.RegisterCameraEntity(cameraEntity, cameraData.name.c_str(), cameraIndex);
 
 		if (cameraData.active || !hasActiveCamera)
 		{
@@ -213,7 +212,6 @@ void Engine::LoadAssets(GameObjects gameObjects, Cameras cameras, Sunlights sunl
 			.shadowBias = sunlightData.shadowBias,
 			.shadowSlopeBias = sunlightData.shadowSlopeBias
 			});
-		renderContext.RegisterSunlightEntity(sunlightEntity, sunlightData.name.c_str());
 
 		if (sunlightData.enabled && !boundFirstEnabledSunlight)
 		{
@@ -324,7 +322,6 @@ void Engine::LoadAssets(GameObjects gameObjects, Cameras cameras, Sunlights sunl
 		const Entity entity = renderService->CreateEntity(mCoordinator, item);
 		item.id = entity;
 		renderContext.CreateRenderItem(item);
-		renderContext.RegisterRenderableEntity(entity, item.name, item.mesh, item.texture);
 	}
 
 	EngineServices services

--- a/source/engine/engine/RenderService.cpp
+++ b/source/engine/engine/RenderService.cpp
@@ -52,12 +52,15 @@ void RenderService::Update(Coordinator& coordinator)
             item.scale = DirectX::SimpleMath::Vector3(transform.scale);
             item.mesh = geo.meshHandle;
             item.texture = mat.textureHandle;
+		item.diffuseStrength = mat.diffuseStrength;
+		item.specularStrength = mat.specularStrength;
+		item.shininess = mat.shininess;
 		strncpy_s(item.name, info.name.c_str(), _TRUNCATE);
 
 		// Update the RenderItem in the RenderContext (not create)
-		size_t renderItemIndex = geo.meshHandle.Index();
-		assert(renderItemIndex < renderContext.renderItems.size() && "RenderItem index out of bounds");
-		renderContext.renderItems[renderItemIndex] = item;
+		RenderItem* renderItem = renderContext.GetRenderItemById(entity);
+		assert(renderItem != nullptr && "RenderItem not found for ECS entity.");
+		*renderItem = item;
 
 		// Here, we can further bridge ECS with Renderer Context as needed
 		// For example, we might want to set additional flags or update other systems

--- a/source/engine/renderer/RenderContext.cpp
+++ b/source/engine/renderer/RenderContext.cpp
@@ -114,7 +114,6 @@ void RenderContext::UnloadAssets()
 	}
 
 	renderItems.clear();
-	sceneEntities.clear();
 	currentSelectedObjectID = ~0u;
 	wasObjectSeleced = false;
 	activeCameraIndex = 0;
@@ -140,48 +139,6 @@ RenderItem* RenderContext::GetRenderItemById(uint32_t id)
 		}
 	}
 	return nullptr;
-}
-
-SceneEntityRecord* RenderContext::GetSceneEntityById(uint32_t id)
-{
-	for (auto& item : sceneEntities)
-	{
-		if (item.id == id)
-		{
-			return &item;
-		}
-	}
-	return nullptr;
-}
-
-void RenderContext::RegisterRenderableEntity(uint32_t id, const char* name, HMesh mesh, HTexture texture)
-{
-	SceneEntityRecord record{};
-	record.id = id;
-	record.kind = SceneEntityKind::Renderable;
-	record.mesh = mesh;
-	record.texture = texture;
-	strncpy_s(record.name, name, _TRUNCATE);
-	sceneEntities.push_back(record);
-}
-
-void RenderContext::RegisterCameraEntity(uint32_t id, const char* name, UINT cameraIndex)
-{
-	SceneEntityRecord record{};
-	record.id = id;
-	record.kind = SceneEntityKind::Camera;
-	record.cameraIndex = cameraIndex;
-	strncpy_s(record.name, name, _TRUNCATE);
-	sceneEntities.push_back(record);
-}
-
-void RenderContext::RegisterSunlightEntity(uint32_t id, const char* name)
-{
-	SceneEntityRecord record{};
-	record.id = id;
-	record.kind = SceneEntityKind::Sunlight;
-	strncpy_s(record.name, name, _TRUNCATE);
-	sceneEntities.push_back(record);
 }
 
 void RenderContext::UpdateSunlightViewProjection()

--- a/source/engine/renderer/RenderContext.h
+++ b/source/engine/renderer/RenderContext.h
@@ -28,23 +28,6 @@ enum RenderTargetFormat
 	R32_UINT
 };
 
-enum class SceneEntityKind : unsigned char
-{
-	Renderable,
-	Camera,
-	Sunlight
-};
-
-struct SceneEntityRecord
-{
-	uint32_t id = UINT32_MAX;
-	SceneEntityKind kind = SceneEntityKind::Renderable;
-	char name[32] = {};
-	HMesh mesh;
-	HTexture texture;
-	UINT cameraIndex = UINT32_MAX;
-};
-
 struct SunlightConstants
 {
 	float lightDirection[4] = { -0.4f, -1.0f, -0.3f, 0.0f };
@@ -147,11 +130,6 @@ public:
 	// High Level
 	std::vector<RenderItem>& GetRenderItems();
 	RenderItem* GetRenderItemById(uint32_t id);
-	const std::vector<SceneEntityRecord>& GetSceneEntities() const { return sceneEntities; }
-	SceneEntityRecord* GetSceneEntityById(uint32_t id);
-	void RegisterRenderableEntity(uint32_t id, const char* name, HMesh mesh, HTexture texture);
-	void RegisterCameraEntity(uint32_t id, const char* name, UINT cameraIndex);
-	void RegisterSunlightEntity(uint32_t id, const char* name);
 	const SunlightConstants& GetSunlightConstants() const { return sunlightConstants; }
 	void SetSunlightConstants(const SunlightConstants& constants) { sunlightConstants = constants; }
 	void UpdateSunlightViewProjection();
@@ -272,7 +250,6 @@ private:
 	std::vector<PipelineState*> pipelineStates;
 	std::vector<InputLayout*> inputLayouts;
 	std::vector<Camera*> cameras;
-	std::vector<SceneEntityRecord> sceneEntities;
 	SunlightConstants sunlightConstants;
 	SunlightViewProjection sunlightViewProjection;
 	HTexture shadowMapTexture;

--- a/source/engine/renderer/RenderItem.h
+++ b/source/engine/renderer/RenderItem.h
@@ -11,6 +11,9 @@ struct RenderItem
 	DirectX::SimpleMath::Vector3 scale = { 1.0f, 1.0f, 1.0f };
 	HMesh mesh;
 	HTexture texture;
+	float diffuseStrength = 1.0f;
+	float specularStrength = 0.65f;
+	float shininess = 32.0f;
 	char name[32];
 	DirectX::SimpleMath::Matrix World() const
 	{

--- a/source/engine/renderer/passes/ForwardPass.cpp
+++ b/source/engine/renderer/passes/ForwardPass.cpp
@@ -61,6 +61,7 @@ void ForwardPass::ConfigurePipelineState()
 	builder.AddSRVTable(1, 1, D3D12_SHADER_VISIBILITY_PIXEL); // SRV t1 (shadow map)
 	builder.AddCBV(3, D3D12_SHADER_VISIBILITY_VERTEX); // CBV b3 (light view-projection)
 	builder.AddCBV(4, D3D12_SHADER_VISIBILITY_PIXEL); // CBV b4 (debug settings)
+	builder.AddConstants(4, 5, 0, D3D12_SHADER_VISIBILITY_PIXEL); // Root Constants @ b5 (camera position)
 	rootSignature = renderContext.CreateRootSignature(builder);
 
 	// Menu height seems to be 20 pixels
@@ -153,6 +154,9 @@ void ForwardPass::Execute()
 	auto type = isPerspectiveCamera ? Camera::CameraType::PERSPECTIVE : Camera::CameraType::ORTHOGRAPHIC;
 	renderContext.GetActiveCamera()->SetType(type);
 	renderContext.SetInlineConstants(commandList, renderContext.GetActiveCamera()->ViewProjecttion(), 0);
+	const DirectX::SimpleMath::Vector3 cameraPosition = renderContext.GetActiveCamera()->GetPosition();
+	const DirectX::SimpleMath::Vector4 cameraPositionConstants(cameraPosition.x, cameraPosition.y, cameraPosition.z, 1.0f);
+	renderContext.SetInlineConstants(commandList, cameraPositionConstants, 8);
 	const SunlightConstants& sunlightConstants = renderContext.GetSunlightConstants();
 	renderContext.UpdateConstantBuffer(sunlightBuffer, &sunlightConstants, sizeof(sunlightConstants));
 	renderContext.BindConstantBuffer(commandList, sunlightBuffer, 2);

--- a/source/engine/renderer/passes/ForwardPass.cpp
+++ b/source/engine/renderer/passes/ForwardPass.cpp
@@ -62,6 +62,7 @@ void ForwardPass::ConfigurePipelineState()
 	builder.AddCBV(3, D3D12_SHADER_VISIBILITY_VERTEX); // CBV b3 (light view-projection)
 	builder.AddCBV(4, D3D12_SHADER_VISIBILITY_PIXEL); // CBV b4 (debug settings)
 	builder.AddConstants(4, 5, 0, D3D12_SHADER_VISIBILITY_PIXEL); // Root Constants @ b5 (camera position)
+	builder.AddConstants(4, 6, 0, D3D12_SHADER_VISIBILITY_PIXEL); // Root Constants @ b6 (material)
 	rootSignature = renderContext.CreateRootSignature(builder);
 
 	// Menu height seems to be 20 pixels
@@ -175,7 +176,13 @@ void ForwardPass::Execute()
 	const auto& items = renderContext.GetRenderItems();
 	for (const RenderItem& item : items)
 	{
+		const DirectX::SimpleMath::Vector4 materialConstants(
+			item.diffuseStrength,
+			item.specularStrength,
+			item.shininess,
+			0.0f);
 		renderContext.SetInlineConstants(commandList, item.World(), 1);
+		renderContext.SetInlineConstants(commandList, materialConstants, 9);
 		renderContext.BindGeometry(commandList, item.mesh);
 		renderContext.BindTexture(commandList, item.texture, 3);
 		renderContext.DrawMesh(commandList, item.mesh);

--- a/source/engine/renderer/passes/ImGuiPass.cpp
+++ b/source/engine/renderer/passes/ImGuiPass.cpp
@@ -353,8 +353,9 @@ void ImGuiPass::DrawGeometrySection(Coordinator& coordinator, Entity entity)
 void ImGuiPass::DrawMaterialComponent(MaterialComponent& material)
 {
 	ImGui::Text("Texture Handle: %zu", material.textureHandle.Index());
-	ImGui::Text("Shininess: %f", material.shininess);
-	ImGui::Text("Specular strength: %f", material.specularStrength);
+	ImGui::DragFloat("Diffuse Strength", &material.diffuseStrength, 0.01f, 0.0f, 10.0f);
+	ImGui::DragFloat("Specular Strength", &material.specularStrength, 0.01f, 0.0f, 10.0f);
+	ImGui::DragFloat("Shininess", &material.shininess, 0.1f, 1.0f, 256.0f);
 }
 
 void ImGuiPass::DrawMaterialSection(Coordinator& coordinator, Entity entity)

--- a/source/engine/renderer/passes/ImGuiPass.cpp
+++ b/source/engine/renderer/passes/ImGuiPass.cpp
@@ -8,8 +8,6 @@
 #include "../../engine/states/EngineCommandQueue.h"
 #include "../../bind/CommandList.h"
 #include "../RenderTarget.h"
-#include "../../engine/Components.h"
-#include "../../engine/Coordinator.h"
 
 #include <imgui.h>
 #include <imgui_impl_dx12.h>
@@ -25,6 +23,13 @@ extern Coordinator* editorCoordinator;
 
 namespace
 {
+	template<typename T>
+	bool HasComponent(Coordinator& coordinator, Entity entity)
+	{
+		Signature signature = coordinator.GetEntityManager()->GetSignature(entity);
+		return signature.test(coordinator.GetComponentType<T>());
+	}
+
 	ImU32 GetHierarchyIconColor(SceneEntityKind kind)
 	{
 		switch (kind)
@@ -301,70 +306,14 @@ void ImGuiPass::Execute()
 			SceneEntityRecord* entity = renderContext.GetSceneEntityById(currentSelection);
 			if (entity != nullptr)
 			{
-				ImGui::Text("Name: %s", entity->name);
 				ImGui::Text("Entity: %u", entity->id);
-				if (entity->kind == SceneEntityKind::Camera)
+				if (editorCoordinator == nullptr)
 				{
-					Camera* camera = renderContext.GetCamera(entity->cameraIndex);
-					const auto position = camera->GetPosition();
-					const auto rotation = camera->GetRotation();
-					ImGui::Text("Kind: Camera");
-					ImGui::Text("Camera Index: %u", entity->cameraIndex);
-					ImGui::Text("Projection: %s",
-						camera->GetType() == Camera::CameraType::ORTHOGRAPHIC ? "Orthographic" : "Perspective");
-					const bool isActiveCamera = renderContext.GetActiveCameraIndex() == entity->cameraIndex;
-					ImGui::Text("Active: %s", isActiveCamera ? "Yes" : "No");
-					ImGui::Text("Position: %.2f, %.2f, %.2f", position.x, position.y, position.z);
-					ImGui::Text("Rotation: %.2f, %.2f, %.2f", rotation.x, rotation.y, rotation.z);
-					if (!isActiveCamera && ImGui::Button("Make Active Camera"))
-					{
-						renderContext.SetActiveCamera(entity->cameraIndex);
-					}
-				}
-				else if (entity->kind == SceneEntityKind::Sunlight)
-				{
-					ImGui::Text("Kind: Sunlight");
-					if (editorCoordinator == nullptr)
-					{
-						ImGui::Text("ECS is unavailable.");
-					}
-					else
-					{
-						Signature signature = editorCoordinator->GetEntityManager()->GetSignature(entity->id);
-						if (!signature.test(editorCoordinator->GetComponentType<SunlightComponent>()))
-						{
-							ImGui::Text("Sunlight component missing.");
-						}
-						else
-						{
-							SunlightComponent& sunlight = editorCoordinator->GetComponent<SunlightComponent>(entity->id);
-							bool changed = false;
-							changed |= ImGui::Checkbox("Enabled", &sunlight.enabled);
-							changed |= ImGui::DragFloat3("Direction", sunlight.direction, 0.01f, -1.0f, 1.0f);
-							changed |= ImGui::ColorEdit3("Color", sunlight.color);
-							changed |= ImGui::DragFloat("Ambient", &sunlight.ambientStrength, 0.01f, 0.0f, 1.0f);
-							changed |= ImGui::DragFloat("Diffuse", &sunlight.diffuseStrength, 0.01f, 0.0f, 10.0f);
-							changed |= ImGui::DragFloat("Shadow Bias", &sunlight.shadowBias, 0.0001f, 0.0f, 0.05f, "%.6f");
-							changed |= ImGui::DragFloat("Shadow Slope Bias", &sunlight.shadowSlopeBias, 0.0001f, 0.0f, 0.05f, "%.6f");
-
-							if (changed)
-							{
-								renderContext.SetSunlightConstants(ToSunlightConstants(sunlight));
-							}
-						}
-					}
+					ImGui::Text("ECS is unavailable.");
 				}
 				else
 				{
-					RenderItem* item = renderContext.GetRenderItemById(currentSelection);
-					if (item != nullptr)
-					{
-						const auto mesh = renderContext.GetMesh(item->mesh);
-						ImGui::Text("Kind: Renderable");
-						ImGui::Text("Vertices: %d", mesh->GetVertexCount());
-						ImGui::Text("Mesh Handle: %zu", item->mesh.Index());
-						ImGui::Text("Texture Handle: %zu", item->texture.Index());
-					}
+					DrawComponentSections(*editorCoordinator, entity->id);
 				}
 			}
 			else
@@ -444,6 +393,134 @@ void ImGuiPass::PostSubmit()
 
 void ImGuiPass::Allocate(DeviceContext* deviceContext)
 {
+}
+
+void ImGuiPass::DrawInfoComponent(InfoComponent& info)
+{
+	ImGui::Text("Name: %s", info.name.c_str());
+}
+
+void ImGuiPass::DrawInfoSection(Coordinator& coordinator, Entity entity)
+{
+	InfoComponent& info = coordinator.GetComponent<InfoComponent>(entity);
+	DrawInfoComponent(info);
+}
+
+void ImGuiPass::DrawTransformComponent(TransformComponent& transform)
+{
+	ImGui::Text("Position: %f, %f, %f", transform.position[0], transform.position[1], transform.position[2]);
+	ImGui::Text("Rotation: %f, %f, %f", transform.rotation[0], transform.rotation[1], transform.rotation[2]);
+	ImGui::Text("Scale: %f, %f, %f", transform.scale[0], transform.scale[1], transform.scale[2]);
+}
+
+void ImGuiPass::DrawTransformSection(Coordinator& coordinator, Entity entity)
+{
+	TransformComponent& transform = coordinator.GetComponent<TransformComponent>(entity);
+	DrawTransformComponent(transform);
+}
+
+void ImGuiPass::DrawGeometrySection(Coordinator& coordinator, Entity entity)
+{
+	GeometryComponent& geometry = coordinator.GetComponent<GeometryComponent>(entity);
+
+	ImGui::Text("Mesh Handle: %zu", geometry.meshHandle.Index());
+	if (geometry.meshHandle.IsValid())
+	{
+		const auto mesh = renderContext.GetMesh(geometry.meshHandle);
+		ImGui::Text("Vertices: %d", mesh->GetVertexCount());
+	}
+}
+
+void ImGuiPass::DrawMaterialComponent(MaterialComponent& material)
+{
+	ImGui::Text("Texture Handle: %zu", material.textureHandle.Index());
+	ImGui::Text("Shininess: %f", material.shininess);
+	ImGui::Text("Specular strength: %f", material.specularStrength);
+}
+
+void ImGuiPass::DrawMaterialSection(Coordinator& coordinator, Entity entity)
+{
+	MaterialComponent& material = coordinator.GetComponent<MaterialComponent>(entity);
+	DrawMaterialComponent(material);
+}
+
+void ImGuiPass::DrawCameraSection(Coordinator& coordinator, Entity entity)
+{
+	CameraComponent& cameraComponent = coordinator.GetComponent<CameraComponent>(entity);
+	Camera* camera = renderContext.GetCamera(static_cast<UINT>(cameraComponent.cameraIndex));
+	const auto position = camera->GetPosition();
+	const auto rotation = camera->GetRotation();
+	const bool isActiveCamera = renderContext.GetActiveCameraIndex() == cameraComponent.cameraIndex;
+
+	ImGui::Text("Camera Index: %zu", cameraComponent.cameraIndex);
+	ImGui::Text("Projection: %s",
+		camera->GetType() == Camera::CameraType::ORTHOGRAPHIC ? "Orthographic" : "Perspective");
+	ImGui::Text("Active: %s", isActiveCamera ? "Yes" : "No");
+	ImGui::Text("Position: %.2f, %.2f, %.2f", position.x, position.y, position.z);
+	ImGui::Text("Rotation: %.2f, %.2f, %.2f", rotation.x, rotation.y, rotation.z);
+
+	if (!isActiveCamera && ImGui::Button("Make Active Camera"))
+	{
+		renderContext.SetActiveCamera(static_cast<UINT>(cameraComponent.cameraIndex));
+		for (Entity candidate = 0; candidate < MAX_ENTITIES; ++candidate)
+		{
+			if (HasComponent<CameraComponent>(coordinator, candidate))
+			{
+				coordinator.GetComponent<CameraComponent>(candidate).active = (candidate == entity);
+			}
+		}
+	}
+}
+
+void ImGuiPass::DrawSunlightSection(Coordinator& coordinator, Entity entity)
+{
+	SunlightComponent& sunlight = coordinator.GetComponent<SunlightComponent>(entity);
+	bool changed = false;
+	changed |= ImGui::Checkbox("Enabled", &sunlight.enabled);
+	changed |= ImGui::DragFloat3("Direction", sunlight.direction, 0.01f, -1.0f, 1.0f);
+	changed |= ImGui::ColorEdit3("Color", sunlight.color);
+	changed |= ImGui::DragFloat("Ambient", &sunlight.ambientStrength, 0.01f, 0.0f, 1.0f);
+	changed |= ImGui::DragFloat("Diffuse", &sunlight.diffuseStrength, 0.01f, 0.0f, 10.0f);
+	changed |= ImGui::DragFloat("Shadow Bias", &sunlight.shadowBias, 0.0001f, 0.0f, 0.05f, "%.6f");
+	changed |= ImGui::DragFloat("Shadow Slope Bias", &sunlight.shadowSlopeBias, 0.0001f, 0.0f, 0.05f, "%.6f");
+
+	if (changed)
+	{
+		renderContext.SetSunlightConstants(ToSunlightConstants(sunlight));
+	}
+}
+
+void ImGuiPass::DrawComponentSections(Coordinator& coordinator, Entity entity)
+{
+	struct ComponentDrawer
+	{
+		const char* label;
+		bool (*has)(Coordinator&, Entity);
+		void (ImGuiPass::*draw)(Coordinator&, Entity);
+	};
+
+	static const ComponentDrawer drawers[] =
+	{
+		{ "Info", HasComponent<InfoComponent>, &ImGuiPass::DrawInfoSection },
+		{ "Transform", HasComponent<TransformComponent>, &ImGuiPass::DrawTransformSection },
+		{ "Geometry", HasComponent<GeometryComponent>, &ImGuiPass::DrawGeometrySection },
+		{ "Material", HasComponent<MaterialComponent>, &ImGuiPass::DrawMaterialSection },
+		{ "Camera", HasComponent<CameraComponent>, &ImGuiPass::DrawCameraSection },
+		{ "Sunlight", HasComponent<SunlightComponent>, &ImGuiPass::DrawSunlightSection },
+	};
+
+	for (const ComponentDrawer& drawer : drawers)
+	{
+		if (!drawer.has(coordinator, entity))
+		{
+			continue;
+		}
+
+		if (ImGui::CollapsingHeader(drawer.label, ImGuiTreeNodeFlags_DefaultOpen))
+		{
+			(this->*drawer.draw)(coordinator, entity);
+		}
+	}
 }
 
 std::string ImGuiPass::OpenFileDialog_Win32(HWND owner)

--- a/source/engine/renderer/passes/ImGuiPass.cpp
+++ b/source/engine/renderer/passes/ImGuiPass.cpp
@@ -30,20 +30,6 @@ namespace
 		return signature.test(coordinator.GetComponentType<T>());
 	}
 
-	ImU32 GetHierarchyIconColor(SceneEntityKind kind)
-	{
-		switch (kind)
-		{
-		case SceneEntityKind::Camera:
-			return IM_COL32(110, 190, 255, 255);
-		case SceneEntityKind::Sunlight:
-			return IM_COL32(255, 220, 90, 255);
-		case SceneEntityKind::Renderable:
-		default:
-			return IM_COL32(255, 180, 90, 255);
-		}
-	}
-
 	SunlightConstants ToSunlightConstants(const SunlightComponent& sunlight)
 	{
 		const float enabled = sunlight.enabled ? 1.0f : 0.0f;
@@ -55,59 +41,6 @@ namespace
 			.shadowBias = sunlight.shadowBias,
 			.shadowSlopeBias = sunlight.shadowSlopeBias
 		};
-	}
-
-	void DrawCameraIcon(ImDrawList* drawList, const ImVec2& topLeft, ImU32 color)
-	{
-		const ImVec2 bodyMin(topLeft.x + 1.5f, topLeft.y + 4.0f);
-		const ImVec2 bodyMax(topLeft.x + 11.5f, topLeft.y + 11.5f);
-		const ImVec2 lensCenter(topLeft.x + 6.5f, topLeft.y + 7.8f);
-		const ImVec2 viewfinderMin(topLeft.x + 4.0f, topLeft.y + 1.8f);
-		const ImVec2 viewfinderMax(topLeft.x + 7.5f, topLeft.y + 4.3f);
-
-		drawList->AddRect(bodyMin, bodyMax, color, 2.5f, 0, 1.8f);
-		drawList->AddRectFilled(viewfinderMin, viewfinderMax, color, 1.0f);
-		drawList->AddCircle(lensCenter, 2.2f, color, 18, 1.7f);
-		drawList->AddCircleFilled(lensCenter, 0.8f, color);
-
-		const ImVec2 barrelA(topLeft.x + 11.5f, topLeft.y + 5.0f);
-		const ImVec2 barrelB(topLeft.x + 15.2f, topLeft.y + 3.6f);
-		const ImVec2 barrelC(topLeft.x + 15.2f, topLeft.y + 11.9f);
-		const ImVec2 barrelD(topLeft.x + 11.5f, topLeft.y + 10.3f);
-		drawList->AddQuad(barrelA, barrelB, barrelC, barrelD, color, 1.6f);
-	}
-
-	void DrawCubeIcon(ImDrawList* drawList, const ImVec2& topLeft, ImU32 color)
-	{
-		const ImVec2 frontTL(topLeft.x + 3.0f, topLeft.y + 5.0f);
-		const ImVec2 frontTR(topLeft.x + 9.0f, topLeft.y + 5.0f);
-		const ImVec2 frontBR(topLeft.x + 9.0f, topLeft.y + 11.0f);
-		const ImVec2 frontBL(topLeft.x + 3.0f, topLeft.y + 11.0f);
-
-		const ImVec2 backTL(topLeft.x + 6.0f, topLeft.y + 2.0f);
-		const ImVec2 backTR(topLeft.x + 12.0f, topLeft.y + 2.0f);
-		const ImVec2 backBR(topLeft.x + 12.0f, topLeft.y + 8.0f);
-		const ImVec2 backBL(topLeft.x + 6.0f, topLeft.y + 8.0f);
-
-		drawList->AddQuad(backTL, backTR, backBR, backBL, color, 1.4f);
-		drawList->AddQuad(frontTL, frontTR, frontBR, frontBL, color, 1.6f);
-		drawList->AddLine(backTL, frontTL, color, 1.4f);
-		drawList->AddLine(backTR, frontTR, color, 1.4f);
-		drawList->AddLine(backBR, frontBR, color, 1.4f);
-		drawList->AddLine(backBL, frontBL, color, 1.4f);
-	}
-
-	void DrawSunlightIcon(ImDrawList* drawList, const ImVec2& topLeft, ImU32 color)
-	{
-		const ImVec2 center(topLeft.x + 8.0f, topLeft.y + 8.0f);
-		drawList->AddCircle(center, 3.0f, color, 18, 1.7f);
-		for (int i = 0; i < 8; ++i)
-		{
-			const float angle = (3.14159265f * 2.0f * static_cast<float>(i)) / 8.0f;
-			const ImVec2 inner(center.x + cosf(angle) * 5.0f, center.y + sinf(angle) * 5.0f);
-			const ImVec2 outer(center.x + cosf(angle) * 7.5f, center.y + sinf(angle) * 7.5f);
-			drawList->AddLine(inner, outer, color, 1.4f);
-		}
 	}
 }
 
@@ -252,39 +185,29 @@ void ImGuiPass::Execute()
 
 	if (ImGui::BeginChild("GameObjectList", ImVec2(0, panelHeight), true))
 	{
-		for (const SceneEntityRecord& entity : renderContext.GetSceneEntities())
+		if (editorCoordinator == nullptr)
 		{
-			bool isSelected = (currentSelection == entity.id);
-
-			ImGui::PushID(static_cast<int>(entity.id));
-			if (ImGui::Selectable("##entity_row", isSelected, ImGuiSelectableFlags_SpanAvailWidth))
+			ImGui::Text("ECS is unavailable.");
+		}
+		else
+		{
+			for (Entity entity = 0; entity < MAX_ENTITIES; ++entity)
 			{
-				renderContext.SetSelectedObjectId(entity.id);
-			}
+				if (!HasComponent<InfoComponent>(*editorCoordinator, entity))
+				{
+					continue;
+				}
 
-			ImDrawList* drawList = ImGui::GetWindowDrawList();
-			const ImVec2 itemMin = ImGui::GetItemRectMin();
-			const ImVec2 itemMax = ImGui::GetItemRectMax();
-			const float iconSize = 16.0f;
-			const ImVec2 iconTopLeft(itemMin.x + 6.0f, itemMin.y + ((itemMax.y - itemMin.y) - iconSize) * 0.5f);
-			const ImU32 iconColor = GetHierarchyIconColor(entity.kind);
+				InfoComponent& info = editorCoordinator->GetComponent<InfoComponent>(entity);
+				const bool isSelected = (currentSelection == entity);
 
-			if (entity.kind == SceneEntityKind::Camera)
-			{
-				DrawCameraIcon(drawList, iconTopLeft, iconColor);
+				ImGui::PushID(static_cast<int>(entity));
+				if (ImGui::Selectable(info.name.c_str(), isSelected, ImGuiSelectableFlags_SpanAvailWidth))
+				{
+					renderContext.SetSelectedObjectId(entity);
+				}
+				ImGui::PopID();
 			}
-			else if (entity.kind == SceneEntityKind::Sunlight)
-			{
-				DrawSunlightIcon(drawList, iconTopLeft, iconColor);
-			}
-			else
-			{
-				DrawCubeIcon(drawList, iconTopLeft, iconColor);
-			}
-
-			const ImVec2 textPos(itemMin.x + 28.0f, itemMin.y + ImGui::GetStyle().FramePadding.y);
-			drawList->AddText(textPos, ImGui::GetColorU32(ImGuiCol_Text), entity.name);
-			ImGui::PopID();
 		}
 	}
 	ImGui::EndChild();
@@ -303,18 +226,14 @@ void ImGuiPass::Execute()
 
 		if (currentSelection != UINT32_MAX)
 		{
-			SceneEntityRecord* entity = renderContext.GetSceneEntityById(currentSelection);
-			if (entity != nullptr)
+			if (editorCoordinator == nullptr)
 			{
-				ImGui::Text("Entity: %u", entity->id);
-				if (editorCoordinator == nullptr)
-				{
-					ImGui::Text("ECS is unavailable.");
-				}
-				else
-				{
-					DrawComponentSections(*editorCoordinator, entity->id);
-				}
+				ImGui::Text("ECS is unavailable.");
+			}
+			else if (HasComponent<InfoComponent>(*editorCoordinator, currentSelection))
+			{
+				ImGui::Text("Entity: %u", currentSelection);
+				DrawComponentSections(*editorCoordinator, currentSelection);
 			}
 			else
 			{

--- a/source/engine/renderer/passes/ImGuiPass.h
+++ b/source/engine/renderer/passes/ImGuiPass.h
@@ -5,6 +5,8 @@
 #include <commdlg.h>
 
 #include "../RenderPass.h"
+#include "../../engine/Components.h"
+#include "../../engine/Coordinator.h"
 
 class RenderPassSettings;;
 
@@ -20,6 +22,16 @@ public:
 	void PostSubmit() override;
 	void Allocate(DeviceContext* deviceContext) override;
 private:
+	void DrawInfoComponent(InfoComponent& info);
+	void DrawTransformComponent(TransformComponent& transform);
+	void DrawInfoSection(Coordinator& coordinator, Entity entity);
+	void DrawTransformSection(Coordinator& coordinator, Entity entity);
+	void DrawGeometrySection(Coordinator& coordinator, Entity entity);
+	void DrawMaterialComponent(MaterialComponent& material);
+	void DrawMaterialSection(Coordinator& coordinator, Entity entity);
+	void DrawCameraSection(Coordinator& coordinator, Entity entity);
+	void DrawSunlightSection(Coordinator& coordinator, Entity entity);
+	void DrawComponentSections(Coordinator& coordinator, Entity entity);
 	std::string OpenFileDialog_Win32(HWND owner = NULL);
 	void DrawRenderPassSettingsWindow(RenderPassSettings* settings);
 	HTexture colorCopyTexture; // Texture to copy color data for ImGui rendering

--- a/source/engine/renderer/shaders/shaders.hlsl
+++ b/source/engine/renderer/shaders/shaders.hlsl
@@ -36,6 +36,11 @@ cbuffer DebugSettings : register(b4)
     float mipVisualizationStrength;
 };
 
+cbuffer CameraPositionData : register(b5)
+{
+    float4 cameraPosition;
+};
+
 struct VSInput
 {
     float4 position : POSITION;
@@ -143,6 +148,10 @@ float4 PSMain(PSInput input) : SV_TARGET
     }
 
     float3 normal = normalize(input.worldNormal);
+    float3 lightDir = -normalize(lightDirection.xyz);
+    float3 viewDir = normalize(cameraPosition.xyz - input.worldPosition);
+    float3 halfVector = normalize(lightDir + viewDir);
+
     float3 shadowNdc = input.shadowPosition.xyz / input.shadowPosition.w;
     float2 shadowUv = shadowNdc.xy * float2(0.5f, -0.5f) + 0.5f;
     float pixelLightDepth = shadowNdc.z;
@@ -155,9 +164,15 @@ float4 PSMain(PSInput input) : SV_TARGET
         pixelLightDepth >= 0.0f && pixelLightDepth <= 1.0f;
     float shadowVisibility = (!insideShadowMap || pixelLightDepth <= shadowMapDepth + depthBias) ? 1.0f : 0.0f;
 
+    static const float shininess = 32.0f;
+    static const float specularStrength = 0.65f;
+
     float diffuse = lightFacing * diffuseStrength;
-    float3 ambientLight = lightColor.xyz * ambientStrength;
-    float3 directLight = lightColor.xyz * diffuse * shadowVisibility;
-    float3 lighting = ambientLight + directLight;
-    return float4(albedo.rgb * lighting, albedo.a);
+    float specular = pow(saturate(dot(normal, halfVector)), shininess);
+    specular *= specularStrength * step(0.00001f, lightFacing);
+
+    float3 ambientLight = albedo.rgb * lightColor.xyz * ambientStrength;
+    float3 directLight = albedo.rgb * lightColor.xyz * diffuse * shadowVisibility;
+    float3 specularLight = lightColor.xyz * specular * shadowVisibility;
+    return float4(ambientLight + directLight + specularLight, albedo.a);
 }

--- a/source/engine/renderer/shaders/shaders.hlsl
+++ b/source/engine/renderer/shaders/shaders.hlsl
@@ -41,6 +41,14 @@ cbuffer CameraPositionData : register(b5)
     float4 cameraPosition;
 };
 
+cbuffer MaterialData : register(b6)
+{
+    float materialDiffuseStrength;
+    float materialSpecularStrength;
+    float materialShininess;
+    float materialPadding;
+};
+
 struct VSInput
 {
     float4 position : POSITION;
@@ -164,12 +172,9 @@ float4 PSMain(PSInput input) : SV_TARGET
         pixelLightDepth >= 0.0f && pixelLightDepth <= 1.0f;
     float shadowVisibility = (!insideShadowMap || pixelLightDepth <= shadowMapDepth + depthBias) ? 1.0f : 0.0f;
 
-    static const float shininess = 32.0f;
-    static const float specularStrength = 0.65f;
-
-    float diffuse = lightFacing * diffuseStrength;
-    float specular = pow(saturate(dot(normal, halfVector)), shininess);
-    specular *= specularStrength * step(0.00001f, lightFacing);
+    float diffuse = lightFacing * diffuseStrength * materialDiffuseStrength;
+    float specular = pow(saturate(dot(normal, halfVector)), materialShininess);
+    specular *= materialSpecularStrength * step(0.00001f, lightFacing);
 
     float3 ambientLight = albedo.rgb * lightColor.xyz * ambientStrength;
     float3 directLight = albedo.rgb * lightColor.xyz * diffuse * shadowVisibility;


### PR DESCRIPTION
## Summary

Adds simple per-entity material controls to the renderer/editor path and moves the hierarchy/details UI to read directly from ECS components instead of the separate `SceneEntityRecord` registry.

## What changed

- Added diffuse strength, specular strength, and shininess fields to material/render item data.
- Passed camera position and material constants into the forward pass so the main shader can apply Blinn-Phong specular lighting.
- Added editable ImGui material controls for selected entities.
- Refactored the hierarchy/details panel to enumerate ECS entities with `InfoComponent` and draw component-specific sections.
- Removed the duplicated scene entity registration path from `RenderContext`.
- Updated render item synchronization to find render items by ECS entity id instead of assuming mesh-handle index alignment.

## Impact

Artists/developers can tune simple material response per renderable entity from the editor details panel. The editor also now reflects the ECS component model more directly, reducing duplicated scene metadata and making future component panels easier to add.

## Validation

- `build_vs2022.bat` completed successfully and regenerated the VS2022 solution/projects.
- `MSBuild.exe build/SuperEZ.sln /m:1 /p:Configuration=Debug /p:Platform=x64 /v:minimal` built `ImGui`, `Engine`, `Game.exe`, and `SceneViewer.exe` successfully.
- The same solution build stops at `UnitTest` because this local environment cannot find `gtest/gtest.h`; no branch-specific compiler errors were seen before that dependency failure.