### PR TITLE
Add debug render target viewer to BlitPass

### DIFF
--- a/source/engine/core/DepthBuffer.h
+++ b/source/engine/core/DepthBuffer.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <Windows.h>
 
 class DepthBuffer
@@ -6,6 +8,7 @@ public:
 	DepthBuffer(UINT width, UINT height, size_t textureIndex, size_t dsvDescriptorIndex, const char* name);
 	size_t GetDescriptorIndex();
 	size_t GetTextureIndex() const { return textureIndex; }
+	const char* GetName() const { return name; }
 	UINT GetWidth() const { return width; }
 	UINT GetHeight() const { return height; }
 private:

--- a/source/engine/renderer/RenderContext.cpp
+++ b/source/engine/renderer/RenderContext.cpp
@@ -696,6 +696,35 @@ void RenderContext::CopyTexture(HCommandList commandList, HTexture source, HText
 	commandLists[commandList.Index()]->GetCommandList()->CopyTextureRegion(&destLocation, 0, 0, 0, &srcLocation, nullptr);
 }
 
+void RenderContext::CopyTextureClamped(HCommandList commandList, HTexture source, HTexture destination)
+{
+	// Like CopyTexture, but clamps the copied region to the smaller of the two
+	// textures so differently sized textures can be copied without tripping the
+	// debug layer. The region is copied to the top-left corner of the destination.
+	const D3D12_RESOURCE_DESC srcDesc = textures[source.Index()]->GetResource()->GetDesc();
+	const D3D12_RESOURCE_DESC dstDesc = textures[destination.Index()]->GetResource()->GetDesc();
+
+	D3D12_TEXTURE_COPY_LOCATION destLocation = {};
+	destLocation.pResource = textures[destination.Index()]->GetResource();
+	destLocation.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+	destLocation.SubresourceIndex = 0;
+
+	D3D12_TEXTURE_COPY_LOCATION srcLocation = {};
+	srcLocation.pResource = textures[source.Index()]->GetResource();
+	srcLocation.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+	srcLocation.SubresourceIndex = 0;
+
+	D3D12_BOX srcBox = {};
+	srcBox.left = 0;
+	srcBox.top = 0;
+	srcBox.front = 0;
+	srcBox.right = static_cast<UINT>(srcDesc.Width < dstDesc.Width ? srcDesc.Width : dstDesc.Width);
+	srcBox.bottom = srcDesc.Height < dstDesc.Height ? srcDesc.Height : dstDesc.Height;
+	srcBox.back = 1;
+
+	commandLists[commandList.Index()]->GetCommandList()->CopyTextureRegion(&destLocation, 0, 0, 0, &srcLocation, &srcBox);
+}
+
 HBuffer RenderContext::CreateTextureUploadBuffer(HTexture textureHandle, UINT64 uploadBufferSize)
 {
 	OutputDebugString(L"CreateTextureUploadBuffer\n");

--- a/source/engine/renderer/RenderContext.h
+++ b/source/engine/renderer/RenderContext.h
@@ -157,16 +157,22 @@ public:
 	HTexture GetTexture(const char* name);
 	std::vector<uint8_t> ReadbackBufferData(HBuffer handle, size_t size);
 	void SetSelectedObjectId(uint32_t id) { currentSelectedObjectID = id; }
+	// Debug RT viewer (BlitPass writes, ImGuiPass reads)
+	void SetDebugViewActive(bool active) { debugViewActive = active; }
+	bool IsDebugViewActive() const { return debugViewActive; }
 	bool WasObjectSelected() { return wasObjectSeleced; }
 	void SetWasObjectSelected(bool value) { wasObjectSeleced = value; }
 	uint32_t GetSelectedObjectId() const { return currentSelectedObjectID; }
 	RenderTarget* GetRenderTarget(HRenderTarget renderTarget) { return renderTargets[renderTarget.Index()]; }
+	const std::vector<RenderTarget*>& GetRenderTargets() const { return renderTargets; }
+	const std::vector<DepthBuffer*>& GetDepthBuffers() const { return depthBuffers; }
 	// Textures
 	HTexture CreateTextureResource(const TextureCreateDesc& desc);
 	HTexture CreateEmptyTexture(TextureCreateDesc desc);
 	HTexture CreateDepthTexture(UINT width, UINT height, const CHAR* name);
 	HTexture CreateRenderTargetTexture(UINT width, UINT height, const CHAR* name, DXGI_FORMAT format);
 	void CopyTexture(HCommandList commandList, HTexture source, HTexture destination);
+	void CopyTextureClamped(HCommandList commandList, HTexture source, HTexture destination);
 	void CopyBufferToTexture(HCommandList commandList, HBuffer buffer, HTexture texture, D3D12_PLACED_SUBRESOURCE_FOOTPRINT layout, UINT subresourceIndex);
 	void CopyTextureToBuffer(HCommandList commandList, HTexture texture, HBuffer buffer, LONG mouseX, LONG mouseY);
 	void CreateDefaultSamplers();
@@ -256,6 +262,7 @@ private:
 private:
 	uint32_t currentSelectedObjectID = ~0u; // ~0u == invalid ID (aka nothing selected)
 	bool wasObjectSeleced = false;
+	bool debugViewActive = false;
 	UINT activeCameraIndex = 0;
 };
 

--- a/source/engine/renderer/RenderPassSettings.cpp
+++ b/source/engine/renderer/RenderPassSettings.cpp
@@ -92,6 +92,23 @@ void RenderPassSettings::AddCombo(
 	group.settings.push_back(setting);
 }
 
+void RenderPassSettings::AddText(
+	const wchar_t* passName,
+	const char* name,
+	const char* label,
+	const char* text)
+{
+	RenderPassSettingsGroup& group = GetOrCreateGroup(passName);
+
+	RenderPassSetting setting;
+	setting.type = RenderPassSettingType::Text;
+	setting.name = name;
+	setting.label = label;
+	setting.value = const_cast<char*>(text); // Read-only; UI never writes through this
+
+	group.settings.push_back(setting);
+}
+
 void RenderPassSettings::AddColorLegend(
 	const wchar_t* passName,
 	const char* name,

--- a/source/engine/renderer/RenderPassSettings.h
+++ b/source/engine/renderer/RenderPassSettings.h
@@ -9,7 +9,8 @@ enum class RenderPassSettingType
 	UInt,
 	Float,
 	Combo,
-	ColorLegend
+	ColorLegend,
+	Text
 };
 
 struct RenderPassSetting
@@ -86,6 +87,14 @@ public:
 		const char* const* labels,
 		const unsigned int* colors,
 		int itemCount);
+
+	// Read-only text block. 'text' must point to a buffer owned by the pass
+	// that stays alive and can be rewritten every frame (e.g. a member char array).
+	void AddText(
+		const wchar_t* passName,
+		const char* name,
+		const char* label,
+		const char* text);
 
 	const std::vector<RenderPassSettingsGroup>& GetGroups() const
 	{

--- a/source/engine/renderer/passes/BlitPass.cpp
+++ b/source/engine/renderer/passes/BlitPass.cpp
@@ -133,10 +133,18 @@ void BlitPass::RegisterSettings(RenderPassSettings& settings)
 			continue;
 		}
 
+		const DXGI_FORMAT format = target->GetFormat();
+		if (format == DXGI_FORMAT_R32G32_UINT)
+		{
+			// debug_blit.hlsl declares SourceUint as a scalar Texture2D<uint>;
+			// an R32G32_UINT SRV has two 32-bit channels and doesn't match
+			// that declaration, so there's no safe way to visualize it yet.
+			continue;
+		}
+
 		DebugSource source;
 		source.texture = renderContext.GetTexture(HRenderTarget(i));
-		const DXGI_FORMAT format = target->GetFormat();
-		if (format == DXGI_FORMAT_R32_UINT || format == DXGI_FORMAT_R32G32_UINT)
+		if (format == DXGI_FORMAT_R32_UINT)
 		{
 			source.mode = VisualizationMode::UintId;
 		}
@@ -238,7 +246,9 @@ void BlitPass::Execute()
 
 	renderContext.TransitionTo(commandList, sourceTexture, D3D12_RESOURCE_STATE_COPY_SOURCE);
 	renderContext.TransitionTo(commandList, backBuffer, D3D12_RESOURCE_STATE_COPY_DEST);
-	renderContext.CopyTexture(commandList, sourceTexture, backBuffer);
+	// DebugBlitTexture is a fixed 1920x1080 regardless of the actual back
+	// buffer size, so clamp the copy region instead of assuming a match.
+	renderContext.CopyTextureClamped(commandList, sourceTexture, backBuffer);
 
 	renderContext.TransitionBack(commandList, sourceTexture);
 	renderContext.TransitionTo(commandList, backBuffer, D3D12_RESOURCE_STATE_PRESENT);

--- a/source/engine/renderer/passes/BlitPass.cpp
+++ b/source/engine/renderer/passes/BlitPass.cpp
@@ -1,13 +1,54 @@
 #include "BlitPass.h"
 #include "../../core/DeviceContext.h"
 #include "../RenderContext.h"
+#include "../RenderTarget.h"
+#include "../../core/DepthBuffer.h"
+#include "../../bind/RootSignatureBuilder.h"
 #include "../../externals/d3dx12/d3dx12.h"
 #include "pix3.h"
+
+#include <cstdio>
+#include <cstring>
 
 extern DeviceContext deviceContext;
 extern RenderContext renderContext;
 
-BlitPass::BlitPass() : RenderPass(L"Blit", L"", Type::Drawless)
+namespace
+{
+	const char* FormatToString(DXGI_FORMAT format)
+	{
+		switch (format)
+		{
+		case DXGI_FORMAT_R8G8B8A8_UNORM: return "R8G8B8A8_UNORM";
+		case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB: return "R8G8B8A8_UNORM_SRGB";
+		case DXGI_FORMAT_R32_FLOAT: return "R32_FLOAT";
+		case DXGI_FORMAT_R32_UINT: return "R32_UINT";
+		case DXGI_FORMAT_R32G32_UINT: return "R32G32_UINT";
+		case DXGI_FORMAT_R32_TYPELESS: return "R32_TYPELESS";
+		case DXGI_FORMAT_D32_FLOAT: return "D32_FLOAT";
+		default: return "<unknown>";
+		}
+	}
+
+	const char* ModeToString(int mode)
+	{
+		switch (mode)
+		{
+		case 0: return "Color";
+		case 1: return "Object IDs (uint)";
+		case 2: return "Depth (grayscale)";
+		case 3: return "Object IDs (uint bits in float)";
+		default: return "<unknown>";
+		}
+	}
+
+	UINT BytesPerPixel(DXGI_FORMAT format)
+	{
+		return format == DXGI_FORMAT_R32G32_UINT ? 8 : 4;
+	}
+}
+
+BlitPass::BlitPass() : RenderPass(L"Blit", L"debug_blit.hlsl", Type::Compute)
 {
 }
 
@@ -17,6 +58,23 @@ BlitPass::~BlitPass()
 
 void BlitPass::ConfigurePipelineState()
 {
+	RootSignatureBuilder builder;
+	builder.AddConstants(1, 0, 0, D3D12_SHADER_VISIBILITY_ALL); // Mode @ b0
+	builder.AddUAVTable(0, 1, D3D12_SHADER_VISIBILITY_ALL); // Output @ u0
+	builder.AddSRVTable(0, 1, D3D12_SHADER_VISIBILITY_ALL); // Float source @ t0
+	builder.AddSRVTable(1, 1, D3D12_SHADER_VISIBILITY_ALL); // Uint source @ t1
+	rootSignature = renderContext.CreateRootSignature(builder);
+
+	TextureCreateDesc textureDesc;
+	textureDesc.width = 1920;
+	textureDesc.height = 1080;
+	textureDesc.format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	textureDesc.name = "DebugBlitTexture";
+	textureDesc.createUav = true;
+	textureDesc.staticSrv = true;
+	textureDesc.staticUav = true;
+	textureDesc.lifeSpan = APP;
+	debugTexture = renderContext.CreateEmptyTexture(textureDesc);
 }
 
 void BlitPass::PostAssetLoad()
@@ -27,25 +85,163 @@ void BlitPass::Initialize()
 {
 }
 
-void BlitPass::Execute()
+void BlitPass::Update()
 {
-	HTexture sourceTexture =
+	const bool overrideActive = debugSourceIndex > 0
+		&& debugSourceIndex <= static_cast<int>(debugSources.size());
+
+	const HTexture texture = overrideActive
+		? debugSources[debugSourceIndex - 1].texture
+		: GetDefaultSourceTexture();
+	const int mode = overrideActive
+		? debugSources[debugSourceIndex - 1].mode
+		: static_cast<int>(VisualizationMode::Color);
+
+	const D3D12_RESOURCE_DESC desc = renderContext.GetTexture(texture)->GetResource()->GetDesc();
+	const float sizeMB = static_cast<float>(desc.Width * desc.Height * BytesPerPixel(desc.Format))
+		/ (1024.0f * 1024.0f);
+
+	snprintf(sourceInfo, sizeof(sourceInfo),
+		"Resolution: %u x %u\n"
+		"Format: %s\n"
+		"Mip levels: %u\n"
+		"View: %s\n"
+		"Size: %.1f MB (mip 0)",
+		static_cast<UINT>(desc.Width), desc.Height,
+		FormatToString(desc.Format),
+		static_cast<UINT>(desc.MipLevels),
+		ModeToString(mode),
+		sizeMB);
+}
+
+void BlitPass::RegisterSettings(RenderPassSettings& settings)
+{
+	// BlitPass is the last pass in the render graph, so by the time this runs
+	// every other pass has already created its render targets and depth buffers.
+	debugSources.clear();
+	debugSourceItems.clear();
+	debugSourceItems.push_back("Default");
+
+	const std::vector<RenderTarget*>& renderTargets = renderContext.GetRenderTargets();
+	for (size_t i = 0; i < renderTargets.size(); ++i)
+	{
+		const RenderTarget* target = renderTargets[i];
+
+		// Back buffers have no SRV and are the blit destination anyway.
+		if (strcmp(target->GetName(), "RT_BackBuffer") == 0)
+		{
+			continue;
+		}
+
+		DebugSource source;
+		source.texture = renderContext.GetTexture(HRenderTarget(i));
+		const DXGI_FORMAT format = target->GetFormat();
+		if (format == DXGI_FORMAT_R32_UINT || format == DXGI_FORMAT_R32G32_UINT)
+		{
+			source.mode = VisualizationMode::UintId;
+		}
+		else if (format == DXGI_FORMAT_R32_FLOAT)
+		{
+			// RenderTargetFormat::R32_UINT maps to an R32_FLOAT resource, and
+			// passes like Selection write raw uint IDs into it (readback picking
+			// reinterprets the bytes, which is why picking works). Bitcast back.
+			source.mode = VisualizationMode::UintBitcast;
+		}
+		else
+		{
+			source.mode = VisualizationMode::Color;
+		}
+		debugSources.push_back(source);
+		debugSourceItems.push_back(target->GetName());
+	}
+
+	const std::vector<DepthBuffer*>& depthBuffers = renderContext.GetDepthBuffers();
+	for (size_t i = 0; i < depthBuffers.size(); ++i)
+	{
+		DebugSource source;
+		source.texture = renderContext.GetTexture(HDepthBuffer(i));
+		source.mode = VisualizationMode::Depth;
+		debugSources.push_back(source);
+		debugSourceItems.push_back(depthBuffers[i]->GetName());
+	}
+
+	settings.AddCombo(
+		GetName(),
+		"blit_source",
+		"Source",
+		&debugSourceIndex,
+		debugSourceItems.data(),
+		static_cast<int>(debugSourceItems.size()));
+
+	settings.AddText(
+		GetName(),
+		"blit_source_info",
+		"Source Info",
+		sourceInfo);
+}
+
+HTexture BlitPass::GetDefaultSourceTexture() const
+{
+	return
 #if IS_EDITOR
 		renderContext.GetTexture("RT_ImGui");
 #else
 		renderContext.GetTexture("RT_ForwardPass");
 #endif
-	renderContext.TransitionTo(commandList, sourceTexture, D3D12_RESOURCE_STATE_COPY_SOURCE);
-	
-	auto frameIndex = deviceContext.GetCurrentBackBufferIndex();
-	HTexture renderTarget = sourceTexture;
-	HTexture backBuffer = HTexture(frameIndex);
-	HTexture frameTexture = HTexture(frameIndex);
-	renderContext.TransitionTo(commandList, frameTexture, D3D12_RESOURCE_STATE_COPY_DEST);
-	renderContext.CopyTexture(commandList, renderTarget, backBuffer);
+}
 
-	renderContext.TransitionBack(commandList, renderTarget);
-	renderContext.TransitionTo(commandList, frameTexture, D3D12_RESOURCE_STATE_PRESENT);
+void BlitPass::Execute()
+{
+	auto frameIndex = deviceContext.GetCurrentBackBufferIndex();
+	HTexture backBuffer = HTexture(frameIndex);
+
+	const bool overrideActive = debugSourceIndex > 0
+		&& debugSourceIndex <= static_cast<int>(debugSources.size());
+
+	HTexture sourceTexture;
+	if (overrideActive)
+	{
+		// Debug view: decode/letterbox the picked texture into the intermediate,
+		// then copy that to the back buffer (same size and format by construction).
+		const DebugSource& source = debugSources[debugSourceIndex - 1];
+		int mode = source.mode;
+
+		renderContext.SetupRenderPass(commandList, pipelineState, rootSignature);
+		renderContext.SetDescriptorHeapCompute(commandList);
+		renderContext.SetInlineConstantsUAV(commandList, 1, &mode, 0);
+
+		renderContext.TransitionTo(commandList, debugTexture, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+		renderContext.TransitionTo(commandList, source.texture, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+		renderContext.BindTextureOnlyUAV(commandList, debugTexture, 1);
+		// The shader declares a float view at t0 and a uint view at t1 and only
+		// reads the one matching the mode, so bind the source to both slots.
+		renderContext.BindTextureOnlySRV(commandList, source.texture, 2);
+		renderContext.BindTextureOnlySRV(commandList, source.texture, 3);
+		renderContext.Dispatch(commandList, (1920 + 7) / 8, (1080 + 7) / 8, 1);
+		renderContext.TransitionBack(commandList, source.texture);
+
+#if IS_EDITOR
+		// Keep the UI usable: ImGuiPass shows DebugBlitTexture in its Viewport
+		// window instead, and the normal UI still reaches the screen.
+		sourceTexture = GetDefaultSourceTexture();
+#else
+		sourceTexture = debugTexture;
+#endif
+	}
+	else
+	{
+		sourceTexture = GetDefaultSourceTexture();
+	}
+
+	// ImGuiPass runs before this pass, so it picks the change up next frame.
+	renderContext.SetDebugViewActive(overrideActive);
+
+	renderContext.TransitionTo(commandList, sourceTexture, D3D12_RESOURCE_STATE_COPY_SOURCE);
+	renderContext.TransitionTo(commandList, backBuffer, D3D12_RESOURCE_STATE_COPY_DEST);
+	renderContext.CopyTexture(commandList, sourceTexture, backBuffer);
+
+	renderContext.TransitionBack(commandList, sourceTexture);
+	renderContext.TransitionTo(commandList, backBuffer, D3D12_RESOURCE_STATE_PRESENT);
 }
 
 void BlitPass::PostSubmit()

--- a/source/engine/renderer/passes/BlitPass.h
+++ b/source/engine/renderer/passes/BlitPass.h
@@ -2,7 +2,12 @@
 
 #include "../RenderPass.h"
 
-// This pass will copy whichever texture requested to the back buffer
+#include <vector>
+
+// This pass will copy whichever texture requested to the back buffer.
+// A debug source can be picked in the Render Pass Settings window; it is
+// decoded and letterbox-scaled into an intermediate texture by a compute
+// shader (debug_blit.hlsl), which is then copied to the back buffer.
 
 class BlitPass : public RenderPass
 {
@@ -12,8 +17,39 @@ public:
 	void ConfigurePipelineState() override;
 	void PostAssetLoad() override;
 	void Initialize() override;
+	void Update() override;
 	void Execute() override;
 	void PostSubmit() override;
 	void Allocate(DeviceContext* deviceContext) override;
+	void RegisterSettings(RenderPassSettings& settings) override;
 private:
+	// Must match the MODE_* defines in debug_blit.hlsl.
+	enum VisualizationMode : int
+	{
+		Color = 0,
+		UintId = 1,
+		Depth = 2,
+		// R32_FLOAT render targets carry raw uint bits (see RenderTargetFormat::R32_UINT mapping)
+		UintBitcast = 3
+	};
+
+	struct DebugSource
+	{
+		HTexture texture;
+		int mode = VisualizationMode::Color;
+	};
+
+	HTexture GetDefaultSourceTexture() const;
+private:
+	// Intermediate back-buffer-sized RGBA8 target for the debug visualization.
+	HTexture debugTexture;
+	// 0 = Default (normal frame output), i > 0 = debugSources[i - 1].
+	int debugSourceIndex = 0;
+	std::vector<DebugSource> debugSources;
+	// Backing storage for the combo labels; RenderPassSetting keeps raw pointers,
+	// so this must live as long as the pass does.
+	std::vector<const char*> debugSourceItems;
+	// Info block about the current source, shown below the combo. Rewritten
+	// every frame in Update(); registered with the settings UI by pointer.
+	char sourceInfo[256] = "";
 };

--- a/source/engine/renderer/passes/ImGuiPass.cpp
+++ b/source/engine/renderer/passes/ImGuiPass.cpp
@@ -256,13 +256,41 @@ void ImGuiPass::Execute()
 	ImGui::SetNextWindowSize(viewport_size, ImGuiCond_Always);
 	ImGui::Begin("Viewport");
 
-	HTexture finalSceneTexture = renderContext.GetTexture("CompositionTexture");
+	// When the debug RT viewer is active (Render Pass Settings -> Blit -> Source),
+	// show the visualized texture in the viewport instead of the scene.
+	HTexture finalSceneTexture = renderContext.IsDebugViewActive()
+		? renderContext.GetTexture("DebugBlitTexture")
+		: renderContext.GetTexture("CompositionTexture");
 	auto finalScene = renderContext.GetTexture(finalSceneTexture);
 	renderContext.TransitionTo(commandList, finalSceneTexture, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
 	auto srvHandleGPU = renderContext.GetSrvHeap().GetGPU(DescriptorHeap::HeapPartition::STATIC, finalScene->GetSrvDescriptorIndex());
 	ImTextureID textureID = (ImTextureID)srvHandleGPU.ptr;
 	ImVec2 size = ImGui::GetContentRegionAvail();
-	ImGui::Image(textureID, size);
+	if (renderContext.IsDebugViewActive())
+	{
+		// DebugBlitTexture is 16:9; stretching it to the viewport region would
+		// distort it, so fit it by aspect ratio and center it instead.
+		const float textureAspect = 1920.0f / 1080.0f;
+		ImVec2 fitted = size;
+		if (fitted.x / fitted.y > textureAspect)
+		{
+			fitted.x = fitted.y * textureAspect;
+		}
+		else
+		{
+			fitted.y = fitted.x / textureAspect;
+		}
+
+		ImVec2 cursor = ImGui::GetCursorPos();
+		ImGui::SetCursorPos(ImVec2(
+			cursor.x + (size.x - fitted.x) * 0.5f,
+			cursor.y + (size.y - fitted.y) * 0.5f));
+		ImGui::Image(textureID, fitted);
+	}
+	else
+	{
+		ImGui::Image(textureID, size);
+	}
 	ImGui::End();
 
 	if (settings != nullptr)
@@ -492,6 +520,12 @@ void ImGuiPass::DrawRenderPassSettingsWindow(RenderPassSettings* settings)
 							static_cast<int*>(setting.value),
 							setting.comboItems,
 							setting.comboItemCount);
+					}
+					else if (setting.type == RenderPassSettingType::Text)
+					{
+						ImGui::Spacing();
+						ImGui::SeparatorText(setting.label);
+						ImGui::TextUnformatted(static_cast<const char*>(setting.value));
 					}
 					else if (setting.type == RenderPassSettingType::ColorLegend)
 					{

--- a/source/engine/renderer/shaders/debug_blit.hlsl
+++ b/source/engine/renderer/shaders/debug_blit.hlsl
@@ -1,0 +1,91 @@
+// Debug render target viewer.
+// Decodes and letterbox-scales an arbitrary source texture into the output,
+// which BlitPass then copies to the back buffer.
+
+#define MODE_COLOR 0
+#define MODE_UINT_ID 1
+#define MODE_DEPTH 2
+// RenderTargetFormat::R32_UINT actually creates an R32_FLOAT resource; passes
+// like Selection write raw uint bits into it, so recover the ID with asuint().
+#define MODE_UINT_BITCAST 3
+
+cbuffer DebugBlitConstants : register(b0)
+{
+    uint Mode;
+};
+
+RWTexture2D<float4> OutColor : register(u0); // UAV
+
+// The same source texture is bound to both slots; only the one matching
+// Mode is ever read, so the type mismatch on the other slot is harmless.
+Texture2D<float4> SourceFloat : register(t0); // SRV (color / depth)
+Texture2D<uint> SourceUint : register(t1);    // SRV (object IDs etc.)
+
+float3 IdToColor(uint id)
+{
+    if (id == 0u || id == 0xFFFFFFFFu)
+    {
+        return float3(0.0f, 0.0f, 0.0f);
+    }
+
+    return float3(
+        ((id * 97u + 13u) % 255u) / 255.0f,
+        ((id * 57u + 41u) % 255u) / 255.0f,
+        ((id * 33u + 71u) % 255u) / 255.0f);
+}
+
+[numthreads(8, 8, 1)]
+void CSMain(uint3 dtid : SV_DispatchThreadID)
+{
+    uint dstWidth, dstHeight;
+    OutColor.GetDimensions(dstWidth, dstHeight);
+    if (dtid.x >= dstWidth || dtid.y >= dstHeight)
+    {
+        return;
+    }
+
+    uint srcWidth, srcHeight;
+    if (Mode == MODE_UINT_ID)
+    {
+        SourceUint.GetDimensions(srcWidth, srcHeight);
+    }
+    else
+    {
+        SourceFloat.GetDimensions(srcWidth, srcHeight);
+    }
+
+    // Letterbox: uniform scale, centered, dark gray outside the source.
+    float scale = min((float)dstWidth / (float)srcWidth, (float)dstHeight / (float)srcHeight);
+    float2 scaledSize = float2(srcWidth, srcHeight) * scale;
+    float2 offset = (float2(dstWidth, dstHeight) - scaledSize) * 0.5f;
+    float2 srcPos = (float2(dtid.xy) - offset) / scale;
+
+    if (srcPos.x < 0.0f || srcPos.y < 0.0f || srcPos.x >= (float)srcWidth || srcPos.y >= (float)srcHeight)
+    {
+        OutColor[dtid.xy] = float4(0.1f, 0.1f, 0.1f, 1.0f);
+        return;
+    }
+
+    int3 loadPos = int3(int2(srcPos), 0);
+
+    float4 result;
+    if (Mode == MODE_UINT_ID)
+    {
+        result = float4(IdToColor(SourceUint.Load(loadPos)), 1.0f);
+    }
+    else if (Mode == MODE_DEPTH)
+    {
+        float depth = SourceFloat.Load(loadPos).r;
+        result = float4(depth, depth, depth, 1.0f);
+    }
+    else if (Mode == MODE_UINT_BITCAST)
+    {
+        result = float4(IdToColor(asuint(SourceFloat.Load(loadPos).r)), 1.0f);
+    }
+    else // MODE_COLOR
+    {
+        result = float4(SourceFloat.Load(loadPos).rgb, 1.0f);
+    }
+
+    OutColor[dtid.xy] = result;
+}


### PR DESCRIPTION
## Summary
- Add a debug render target viewer to `BlitPass`: pick any render target or depth buffer from the Render Pass Settings window and view it in the editor viewport.
- Decode the picked source with a new compute shader (`debug_blit.hlsl`) that handles color, object-ID, depth, and bitcast-uint sources, and letterbox-scale it into an intermediate texture.
- Add `RenderPassSettings::AddText` for a read-only info block (resolution, format, mip count, view mode, size) shown under the source picker.

## Test plan
- [ ] Build and run the editor, open Render Pass Settings -> Blit, and cycle through each source in the dropdown.
- [ ] Confirm the viewport shows the letterboxed debug view and the info block updates per source.
- [ ] Confirm switching back to "Default" restores the normal scene output.